### PR TITLE
Fix settings handling

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,10 +14,14 @@ var (
 )
 
 func main() {
-	// Use ReadConfig to read .devxp yaml file and print out content
-	settings, err := config.ReadConfig(".devxp")
-	if err != nil {
-		panic(err)
+	// If there is a config file in ~/.local/devxp/config.yml, use that.
+	// Otherwise, use the default .devxp file in the current directory.
+	// If neither is found, use default settings.
+	settings := config.DefaultSettings()
+	if userSettings, err := config.ReadConfig("~/.local/devxp/config.yml"); err == nil {
+		settings = config.MergeSettings(settings, userSettings)
+	} else if localSettings, err := config.ReadConfig(".devxp"); err == nil {
+		settings = config.MergeSettings(settings, localSettings)
 	}
 
 	if cmdErr := cmd.Execute(settings, version); cmdErr != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,13 +24,13 @@ func ReadConfig(filepath string) (*Settings, error) {
 
 func DefaultSettings() *Settings {
 	return &Settings{
-		ProjectType: "default",
+		ProjectType: "",
 	}
 }
 
-func MergeSettings(source *Settings, user *Settings) *Settings {
-	if user.ProjectType != "" {
-		source.ProjectType = user.ProjectType
+func MergeSettings(source *Settings, newSettings *Settings) *Settings {
+	if newSettings.ProjectType != "" {
+		source.ProjectType = newSettings.ProjectType
 	}
 
 	return source

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,3 +21,17 @@ func ReadConfig(filepath string) (*Settings, error) {
 
 	return &cfg, nil
 }
+
+func DefaultSettings() *Settings {
+	return &Settings{
+		ProjectType: "default",
+	}
+}
+
+func MergeSettings(source *Settings, user *Settings) *Settings {
+	if user.ProjectType != "" {
+		source.ProjectType = user.ProjectType
+	}
+
+	return source
+}

--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -2,18 +2,5 @@ package config
 
 // Settings represents the configuration settings for the gh-dxp extension.
 type Settings struct {
-	Lint LintSettings `yaml:"lint"`
-}
-
-// LintSettings represents the configuration settings for the linting process.
-type LintSettings struct {
-	Linters []LinterSettings `yaml:"linters"`
-	Exclude []string         `yaml:"exclude"`
-}
-
-// LinterSettings represents the configuration settings for a specific linter.
-type LinterSettings struct {
-	Name    string   `yaml:"name"`
-	Include []string `yaml:"include"`
-	Exclude []string `yaml:"exclude"`
+	ProjectType string `yaml:"projectType"`
 }


### PR DESCRIPTION
Summary:
The extension should no longer require a .devxp file in the repo to run.
If ~/.local/devxp/config.yml exists, that file is used.
Issue ID(s): TDX-494

Testing:
- [x] Unit Tests
- [ ] Integration Tests
- Test Command: make test


Documentation:
- No updates
