### PR TITLE
Add test command and include in pr flow [minor]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,35 +11,35 @@ jobs:
     permissions: write-all
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-    - name: Calculate application version
-      id: version
-      uses: paulhatch/semantic-version@v5.4.0
-      with:
-        version_format: "v${major}.${minor}.${patch}"
-        major_pattern: "[major]"
-        minor_pattern: "[minor]"
-        bump_each_commit_patch_pattern: "[patch]"
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Calculate application version
+        id: version
+        uses: paulhatch/semantic-version@v5.4.0
+        with:
+          version_format: "v${major}.${minor}.${patch}"
+          major_pattern: "[major]"
+          minor_pattern: "[minor]"
+          bump_each_commit_patch_pattern: "[patch]"
 
-    - name: Tag commit
-      uses: actions/github-script@v7
-      with:
-        script: |
-          github.rest.git.createRef({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            ref: 'refs/tags/${{ steps.version.outputs.version }}',
-            sha: context.sha
-          })
-    - name: Checkout post tag
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-    - uses: cli/gh-extension-precompile@v1
-      name: Create extension release
-      with:
-        go_version: "1.22"
-        build_script_override: "build_release_version.sh"  
+      - name: Tag commit
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'refs/tags/${{ steps.version.outputs.version }}',
+              sha: context.sha
+            })
+      - name: Checkout post tag
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: cli/gh-extension-precompile@v1
+        name: Create extension release
+        with:
+          go_version: "1.22"
+          build_script_override: "build_release_version.sh"

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ In addition, there are some convenience operations available to support our dail
 This runs the installed linters on the given repository. Linters need to be configured, either locally in the repository, or with a config file in your home directory.
 
    ```sh
-   gh dxp unit
+   gh dxp test
    ```
 
 This runs unit tests on the given repository. The extension will try to guess the unit test framework to run based on project type, but it can also be configured in the configuration files.

--- a/build_release_version.sh
+++ b/build_release_version.sh
@@ -19,7 +19,7 @@ compile() {
 
   GOOS=${GOOS} GOARCH=${GOARCH} go build -o "${OUTPUT}" .
   
-  if [ $? -ne 0 ]; then
+  if ! GOOS; then
     echo "Error building for ${GOOS}/${GOARCH}"
     exit 1
   fi

--- a/build_release_version.sh
+++ b/build_release_version.sh
@@ -17,7 +17,7 @@ compile() {
 
   echo "Building for ${GOOS}/${GOARCH}..."
 
-  GOOS=${GOOS} GOARCH=${GOARCH} go build -o ${OUTPUT} .
+  GOOS=${GOOS} GOARCH=${GOARCH} go build -o "${OUTPUT}" .
   
   if [ $? -ne 0 ]; then
     echo "Error building for ${GOOS}/${GOARCH}"
@@ -28,7 +28,7 @@ compile() {
 # Iterate over platforms and compile for each
 for PLATFORM in "${PLATFORMS[@]}"; do
   IFS="/" read -r GOOS GOARCH <<< "${PLATFORM}"
-  compile ${GOOS} ${GOARCH}
+  compile "${GOOS}" "${GOARCH}"
 done
 
 echo "All builds completed successfully."

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -52,6 +52,7 @@ func GenerateCmd(settings *config.Settings, version string) *cobra.Command {
 		LintCmd(exe, settings),
 		MergeCmd(exe),
 		BranchCmd(exe),
+		TestCmd(exe),
 	)
 
 	return retCmd

--- a/pkg/cmd/test.go
+++ b/pkg/cmd/test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// TestCmd handles the running of tests.
 func TestCmd(exe utils.Executor) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "test",
@@ -14,10 +15,9 @@ func TestCmd(exe utils.Executor) *cobra.Command {
 		Args:  cobra.ExactArgs(0),
 		Long: heredoc.Docf(`
 			Run tests based on project type`, "`"),
-		RunE: func(_ *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			res := test.RunTest(exe)
 			return res
-
 		},
 	}
 	return cmd

--- a/pkg/cmd/test.go
+++ b/pkg/cmd/test.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"github.com/MakeNowJust/heredoc"
+	"github.com/elhub/gh-dxp/pkg/test"
+	"github.com/elhub/gh-dxp/pkg/utils"
+	"github.com/spf13/cobra"
+)
+
+func TestCmd(exe utils.Executor) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "test",
+		Short: "Run tests",
+		Args:  cobra.ExactArgs(0),
+		Long: heredoc.Docf(`
+			Run tests based on project type`, "`"),
+		RunE: func(_ *cobra.Command, args []string) error {
+			res := test.RunTest(exe)
+			return res
+
+		},
+	}
+	return cmd
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -22,12 +22,14 @@ func ReadConfig(filepath string) (*Settings, error) {
 	return &cfg, nil
 }
 
+// DefaultSettings loads the default .devxp settings.
 func DefaultSettings() *Settings {
 	return &Settings{
 		ProjectType: "",
 	}
 }
 
+// MergeSettings merges two settings.
 func MergeSettings(source *Settings, newSettings *Settings) *Settings {
 	if newSettings.ProjectType != "" {
 		source.ProjectType = newSettings.ProjectType

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -25,7 +25,7 @@ func writeTempFile(t *testing.T, text []byte) *os.File {
 	return tmpfile
 }
 
-// TestReadConfig tests the ReadConfig function
+// TestReadConfig tests the ReadConfig function.
 func TestReadConfig(t *testing.T) {
 	t.Run("valid config file", func(t *testing.T) {
 		// Create a temporary file
@@ -59,7 +59,7 @@ projectTypes:
 	})
 }
 
-// Test the MergeSettings function
+// Test the MergeSettings function.
 func TestMergeSettings(t *testing.T) {
 	defaultSettings := config.DefaultSettings()
 	userSettings := &config.Settings{

--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -52,7 +52,8 @@ func TestRun(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockExe := new(mockExecutor)
-			args := []string{"mega-linter-runner", "--flavor", "cupcake", "-e", "MEGALINTER_CONFIG=https://raw.githubusercontent.com/elhub/devxp-lint-configuration/main/resources/.mega-linter.yml"}
+			args := []string{"mega-linter-runner", "--flavor", "cupcake", "-e",
+				"MEGALINTER_CONFIG=https://raw.githubusercontent.com/elhub/devxp-lint-configuration/main/resources/.mega-linter.yml"}
 			mockExe.On("CommandContext", mock.Anything, "npx", args).Return(nil, tt.mockError)
 
 			err := lint.Run(mockExe, &config.Settings{})

--- a/pkg/pr/pr.go
+++ b/pkg/pr/pr.go
@@ -133,9 +133,16 @@ func generatePRArgs(options *Options) []string {
 }
 
 func update(exe utils.Executor, branchID string, prID string) error {
+
+	//Run tests
+	err := test.RunTest(exe)
+	if err != nil {
+		return err
+	}
+
 	// Push the current branch to the already existing git remote
 	s := utils.StartSpinner("Updating Pull Request #"+prID+"...", "Pull Request #"+prID+" has been updated.")
-	_, err := exe.Command("git", "push")
+	_, err = exe.Command("git", "push")
 	s.Stop()
 	if err != nil {
 		return err

--- a/pkg/pr/pr.go
+++ b/pkg/pr/pr.go
@@ -9,6 +9,7 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/caarlos0/log"
 	"github.com/elhub/gh-dxp/pkg/branch"
+	"github.com/elhub/gh-dxp/pkg/test"
 	"github.com/elhub/gh-dxp/pkg/utils"
 	"github.com/pkg/errors"
 )
@@ -71,6 +72,12 @@ func create(exe utils.Executor, options *Options, branchID string) error {
 			}
 
 		}
+	}
+
+	//Run tests
+	err = test.RunTest(exe)
+	if err != nil {
+		return err
 	}
 
 	// Push the current branch to git remote

--- a/pkg/pr/pr_test.go
+++ b/pkg/pr/pr_test.go
@@ -172,6 +172,7 @@ func TestExecute(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockExe := new(MockExecutor)
+			mockExe.On("Command", "git", []string{"rev-parse", "--show-toplevel"}).Return("/home/repo-name", nil)
 			mockExe.On("Command", "git", []string{"status", "--porcelain"}).Return(tt.currentChanges, nil)
 			mockExe.On("Command", "git", []string{"branch", "--show-current"}).Return(tt.currentBranch, tt.currentBranchErr)
 			mockExe.On("Command", "git", []string{"push"}).Return(tt.pushBranch, tt.pushBranchErr)

--- a/pkg/test/test.go
+++ b/pkg/test/test.go
@@ -1,0 +1,102 @@
+package test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/caarlos0/log"
+	"github.com/elhub/gh-dxp/pkg/utils"
+)
+
+var FileExists = utils.FileExists
+
+func RunTest(exe utils.Executor) error {
+
+	cmd, err := resolveTestCommand(exe)
+	if err != nil {
+		switch e := err.(type) {
+		case *NoTestCommandError:
+			log.Warn(e.Msg)
+			return nil
+		default:
+			return err
+		}
+
+	}
+
+	ctx := context.Background()
+	err = exe.CommandContext(ctx, cmd, "test")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resolveTestCommand(exe utils.Executor) (string, error) {
+
+	root, err := getGitRootDirectory(exe)
+	if err != nil {
+		return "", err
+	}
+
+	if makeTestInGitRoot(root) {
+		return "make", nil
+	}
+
+	if gradleTestInGitRoot(root) {
+		return "./gradlew", nil
+	}
+	if mavenTestInGitRoot(root) {
+		return "mvn", nil
+	}
+	if npmTestInGitRoot(root) {
+		return "npm", nil
+	}
+	return "", &NoTestCommandError{Msg: "No test command found"}
+}
+
+func getGitRootDirectory(exe utils.Executor) (string, error) {
+	//Locate the root directory of current git repo
+	//Fails if not in a repo
+
+	root, err := exe.Command("git", "rev-parse", "--show-toplevel")
+	if err != nil {
+		return "", &NotAGitRepoError{Msg: "Not a git repo"}
+	}
+
+	return strings.TrimSuffix(root, "\n"), nil
+}
+
+func gradleTestInGitRoot(root string) bool {
+	return FileExists(fmt.Sprintf("%s/gradlew", root))
+}
+
+func makeTestInGitRoot(root string) bool {
+	return FileExists(fmt.Sprintf("%s/Makefile", root))
+}
+
+func mavenTestInGitRoot(root string) bool {
+	return FileExists(fmt.Sprintf("%s/pom.xml", root))
+}
+
+func npmTestInGitRoot(root string) bool {
+	return FileExists(fmt.Sprintf("%s/package.json", root))
+}
+
+type NoTestCommandError struct {
+	Msg string
+}
+
+type NotAGitRepoError struct {
+	Msg string
+}
+
+func (e *NotAGitRepoError) Error() string {
+	return e.Msg
+}
+
+func (e *NoTestCommandError) Error() string {
+	return e.Msg
+}

--- a/pkg/test/test_test.go
+++ b/pkg/test/test_test.go
@@ -1,0 +1,102 @@
+package test_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/elhub/gh-dxp/pkg/test"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+type MockExecutor struct {
+	mock.Mock
+}
+
+func (m *MockExecutor) Command(name string, arg ...string) (string, error) {
+	args := m.Called(name, arg)
+	return args.String(0), args.Error(1)
+}
+
+func (m *MockExecutor) CommandContext(ctx context.Context, name string, arg ...string) error {
+	args := m.Called(ctx, name, arg)
+	return args.Error(1)
+}
+
+func (m *MockExecutor) GH(arg ...string) (bytes.Buffer, error) {
+	args := m.Called(arg)
+	return *bytes.NewBufferString(args.String(0)), args.Error(1)
+}
+
+func TestExecute(t *testing.T) {
+
+	tests := []struct {
+		name         string
+		gitRoot      string
+		gitRootError error
+		expectedErr  error
+		testFile     string
+	}{
+		{
+			name:     "Test Makefile",
+			gitRoot:  "/home/repo-name",
+			testFile: "/home/repo-name/Makefile",
+		},
+		{
+			name:     "Test Gradlew",
+			gitRoot:  "/home/repo-name",
+			testFile: "/home/repo-name/Gradlew",
+		},
+		{
+			name:     "Test npm",
+			gitRoot:  "/home/repo-name",
+			testFile: "/home/repo-name/package.json",
+		},
+		{
+			name:     "Test maven",
+			gitRoot:  "/home/repo-name",
+			testFile: "/home/repo-name/pom.xml",
+		},
+		{
+			name:        "Failing test",
+			gitRoot:     "/home/repo-name",
+			testFile:    "/home/repo-name/Makefile",
+			expectedErr: errors.New("failed tests"),
+		},
+		{
+			name:    "No test file",
+			gitRoot: "/home/repo-name",
+		},
+		{
+			name:         "Not in git repo",
+			gitRootError: errors.New("Not a git repo"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			test.FileExists = func(path string) bool {
+				return path == tt.testFile
+			}
+
+			mockExe := new(MockExecutor)
+
+			mockExe.On("Command", "git", []string{"rev-parse", "--show-toplevel"}).Return(tt.gitRoot, tt.gitRootError)
+			mockExe.On("CommandContext", mock.Anything, "gradlew", []string{"test"}).Return(nil, tt.expectedErr)
+			mockExe.On("CommandContext", mock.Anything, "make", []string{"test"}).Return(nil, tt.expectedErr)
+			mockExe.On("CommandContext", mock.Anything, "npm", []string{"test"}).Return(nil, tt.expectedErr)
+			mockExe.On("CommandContext", mock.Anything, "mvn", []string{"test"}).Return(nil, tt.expectedErr)
+
+			err := test.RunTest(mockExe)
+
+			if tt.expectedErr != nil || tt.gitRootError != nil {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/test/test_test.go
+++ b/pkg/test/test_test.go
@@ -31,7 +31,6 @@ func (m *MockExecutor) GH(arg ...string) (bytes.Buffer, error) {
 }
 
 func TestExecute(t *testing.T) {
-
 	tests := []struct {
 		name         string
 		gitRoot      string
@@ -77,7 +76,6 @@ func TestExecute(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
 			test.FileExists = func(path string) bool {
 				return path == tt.testFile
 			}

--- a/pkg/utils/files.go
+++ b/pkg/utils/files.go
@@ -2,6 +2,7 @@ package utils
 
 import "os"
 
+// FileExists returns true if a given file exists, and false if it doesn't.
 func FileExists(path string) bool {
 	_, err := os.Stat(path)
 	return !os.IsNotExist(err)


### PR DESCRIPTION
This PR adds a new command ("gh dxp test") that will look for one of four possible files and run a test command based on these. If no command is found, it will proceed. If a command is found, but returns an error, it will fail. 

The command is also automatically called in the PR flow.

This does _not_ introduce configuration of the test command using the .devxp file

Summary:
- add test command


Testing:
- [x] Unit Tests
- [ ] Integration Tests
- Test Command: make test


Documentation:
- No updates
