### PR TITLE
Add codeowners parsing and update template files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+# EditorConfig helps developers define and maintain consistent coding styles between different editors and IDEs
+# editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+max_line_length = 160
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{java,kt,kts,scala,rs,xml,kt.spec,kts.spec}]
+indent_size = 4
+
+[*.{kt,kts}]
+ktlint_code_style = ktlint_official
+ktlint_standard_max-line-length = 160
+ktlint_standard = enabled
+
+[{*.py, *.pyi}]
+indent_size = 4

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,39 @@
+# Handle line endings automatically for files detected as text and leave all files detected as binary untouched.
+* text=auto
+
+# Force the following filetypes to have unix eols, so Windows does not break them
+*.* text eol=lf
+
+# Explicit windows files should use crlf
+*.bat text eol=crlf
+*.cmd text eol=crlf
+
+# These files are binary and should be left untouched
+# (binary is a macro for -text -diff)
+*.7z        binary
+*.bz2       binary
+*.catalog   binary
+*.eot       binary
+*.ez        binary
+*.fla       binary
+*.flv       binary
+*.jpg       binary
+*.jpeg      binary
+*.gif       binary
+*.gz        binary
+*.ico       binary
+*.mov       binary
+*.mp4       binary
+*.mp3       binary
+*.otf       binary
+*.pdf       binary
+*.png       binary
+*.pyc       binary
+*.rpd       binary
+*.swf       binary
+*.swp       binary
+*.ttf       binary
+*.woff      binary
+*.woff2     binary
+*.xlsx      binary
+*.zip       binary

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# The CODEOWNERS file defines which team has responsibility and expertise on the code
+# in this repository.
+#
+# Team definitions:
+# https://github.com/orgs/elhub/teams
+
+# Default Repository Owner
+* @elhub/devxp
+*.md @elhub/platform

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,4 +6,3 @@
 
 # Default Repository Owner
 * @elhub/devxp
-*.md @elhub/platform

--- a/.github/CONTRIBUTING
+++ b/.github/CONTRIBUTING
@@ -1,0 +1,35 @@
+# Contributing
+
+So you want to code? Awesome. The following is the contributing guide for Elhub development inner-source code. Please read these guidelines if you haven't
+done so before. By following these guidelines, you will save the owning team both time and effort, and they will be better able to help you in addressing
+your issues, assess changes, and helping you finalize any contributions to the project.
+
+You can contribute in many ways to the project:
+
+* Submit bug reports or feature requests
+* Improve the documentation, either the README here or the documentation on confluence (see README for link)
+* Hack on the project itself by fixing bugs you've found or adding new features
+
+If you have more general questions about this project, use the Team Dev Teams channel.
+
+## How to Report a bug or suggest a feature/enchancement
+
+If you are an Elhub employee, follow the [guidelines on Confluence](https://confluence.elhub.cloud/display/DEV/How+to+Submit+a+Bug+or+Feature+Request).
+
+If you are accessing this repository on Github, submit an issue using the project's issue board on Github.
+
+## How to Fix a bug or Add a feature/enhancement
+
+If you are an Elhub employee, follow the [guidelines on Confluence](https://confluence.elhub.cloud/pages/viewpage.action?pageId=641763474).
+
+If you are looking at this repository on Github, feel free to submit a PR. Is this new to you? You can learn how to do it from this *free* set of tutorials:
+[How to Contribute to an Open Source Project on GitHub](https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github).
+
+All code that is submitted into the project is code-reviewed by the responsible team (listed in CODEOWNERS) before being pushed into the repository.
+
+Expectations:
+
+* Create an issue for any major change or enhancement before writing any code. Creating an issue allows the change to be discussed openly by the team.
+* Ensure that code submitted follow our code guidelines (running the linters will ensure this).
+* Keep commits as small as possible, preferably one change per commit.
+* Be considerate and respectful to others.

--- a/.gitignore
+++ b/.gitignore
@@ -1,22 +1,25 @@
-### Binary
-gh-dxp
-
 ### Local Lint Files
 .checkmake.ini
 .jsonlintrc
 .golangci.yml
 .markdownlint.json
 .prettierrc.json
+.stylelintrc.json
 .yamllint.yml
 revive.toml
 
 ### Elhub-Ansible
-ansible/galaxy/*
-ansible/inventories/*
-ansible/vault_ids/*
-!ansible/galaxy/.gitkeep
-!ansible/inventories/.gitkeep
-!ansible/vault_ids/.gitkeep
+**/galaxy/*
+**/inventories/*
+!**/galaxy/.gitkeep
+!**/inventories/.gitkeep
+
+### Backup files
+**/*.bkp
+**/*.bak
+
+### Env files
+*.env
 
 ### Intellij+all Patch ###
 # Ignores the whole .idea folder and all .iml files
@@ -50,9 +53,6 @@ gradle-app.setting
 
 ### Gradle Patch ###
 **/build/
-# do not remove
-!src/main/kotlin/no/elhub/devxp/build
-!src/test/kotlin/no/elhub/devxp/build
 
 ### Maven ###
 target/
@@ -114,8 +114,3 @@ dist/
 /coverage
 /allure-report
 /allure-results
-
-### Python ###
-__pycache__/
-*.py[cod]
-*$py.class

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -2,9 +2,19 @@ import no.elhub.devxp.build.configuration.pipeline.ElhubProject.Companion.elhubP
 import no.elhub.devxp.build.configuration.pipeline.constants.Group.DEVXP
 import no.elhub.devxp.build.configuration.pipeline.jobs.makeVerify
 
+
 elhubProject(DEVXP, "gh-dxp") {
 
-    pipeline(withReleaseVersion = false) {
-        makeVerify()
+    params {
+        param("env.PATH", "\$PATH:/opt/go/1.21.6/bin")
+        param("env.GOROOT", "/opt/go/1.21.6")
+    }
+
+    pipeline {
+        sequential {
+            makeVerify {
+                disableSonarScan = true
+            }
+        }
     }
 }

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -2,22 +2,9 @@ import no.elhub.devxp.build.configuration.pipeline.ElhubProject.Companion.elhubP
 import no.elhub.devxp.build.configuration.pipeline.constants.Group.DEVXP
 import no.elhub.devxp.build.configuration.pipeline.jobs.makeVerify
 
-elhubProject(DEVXP, "devxp-jira-scripts") {
+elhubProject(DEVXP, "gh-dxp") {
 
-    params {
-<<<<<<< HEAD
-        param("env.PATH", "\$PATH:/opt/go/1.21.6/bin")
-=======
-        param("env.PATH", "/opt/go/1.21.6/bin:%teamcity.tool.maven.DEFAULT%/bin:%KOTLIN_PATH%:%env.PATH%:/home/teamcity/.nvm/versions/node/v20.10.0/bin")
->>>>>>> 6a9ae7f4911a33d665cfb99d95d183a741439e99
-        param("env.GOROOT", "/opt/go/1.21.6")
-    }
-
-    pipeline {
-        sequential {
-            makeVerify {
-                disableSonarScan = true
-            }
-        }
+    pipeline(withReleaseVersion = false) {
+        makeVerify()
     }
 }

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,0 @@
-# Default Codeowners for Repository
-*	@elhub/devxp

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
 BINARY_NAME=gh-dxp
 BUILD_DIR=build
+BIN_DIR=${BUILD_DIR}/gh-dxp
 
 .PHONY: all clean check
 
-all: clean dep check vet lint build
+all: clean dep check vet build
 
 build:
-	go build -o ${BUILD_DIR}/${BINARY_NAME}
+	go build -o ${BIN_DIR}/${BINARY_NAME}
 
 check:
 	mkdir -p ${BUILD_DIR}
@@ -22,10 +23,10 @@ dep:
 
 install: clean build
 	-gh extension remove ${BINARY_NAME}
-	cp ${BUILD_DIR}/${BINARY_NAME} .; gh extension install .
+	cd ${BIN_DIR}; gh extension install .
 
 run: build
-	${BUILD_DIR}/${BINARY_NAME}
+	${BIN_DIR}/${BINARY_NAME}
 
 vet:
 	go vet

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/elliotchance/orderedmap/v2 v2.2.0 // indirect
 	github.com/fatih/color v1.7.0 // indirect
+	github.com/hmarr/codeowners v1.1.2 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 h1:2VTzZjLZBgl62/EtslC
 github.com/henvic/httpretty v0.0.6 h1:JdzGzKZBajBfnvlMALXXMVQWxWMF/ofTy8C3/OSUTxs=
 github.com/henvic/httpretty v0.0.6/go.mod h1:X38wLjWXHkXT7r2+uK8LjCMne9rsuNaBLJ+5cU2/Pmo=
 github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec/go.mod h1:Q48J4R4DvxnHolD5P8pOtXigYlRuPLGl6moFx3ulM68=
+github.com/hmarr/codeowners v1.1.2 h1:CdmLJ0e2s2aaH21+3HW1HXJyJqz+OCEiMBfD9iZb3n8=
+github.com/hmarr/codeowners v1.1.2/go.mod h1:+ez+YARvfVhzL1MzY0f2+D/VusjODs4iRj3tO/IxBMw=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
@@ -79,10 +81,13 @@ github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRM
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/thlib/go-timezone-local v0.0.0-20210907160436-ef149e42d28e h1:BuzhfgfWQbX0dWzYzT1zsORLnHRv3bcRcsaUk0VmXA8=

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -51,6 +51,7 @@ func GenerateCmd(settings *config.Settings, version string) *cobra.Command {
 		BranchCmd(exe),
 		LintCmd(exe, settings),
 		MergeCmd(exe),
+		OwnerCmd(exe, settings),
 		PRCmd(exe),
 		TestCmd(exe),
 		TemplateCmd(exe, settings),

--- a/pkg/cmd/owner.go
+++ b/pkg/cmd/owner.go
@@ -24,7 +24,7 @@ func OwnerCmd(exe utils.Executor, settings *config.Settings) *cobra.Command {
 		`),
 		RunE: func(_ *cobra.Command, args []string) error {
 			path := args[0]
-			return owner.Execute(path)
+			return owner.Execute(path, exe)
 		},
 	}
 

--- a/pkg/cmd/owner.go
+++ b/pkg/cmd/owner.go
@@ -26,7 +26,7 @@ func OwnerCmd(exe utils.Executor, _ *config.Settings) *cobra.Command {
 		`),
 		RunE: func(_ *cobra.Command, args []string) error {
 			var path string
-			if len(args) > 1 {
+			if len(args) > 0 {
 				path = args[0]
 			} else {
 				defaultPath, err := owner.GetDefaultFile(exe)

--- a/pkg/cmd/owner.go
+++ b/pkg/cmd/owner.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"github.com/MakeNowJust/heredoc"
+	"github.com/elhub/gh-dxp/pkg/config"
+	"github.com/elhub/gh-dxp/pkg/owner"
+	"github.com/elhub/gh-dxp/pkg/utils"
+	"github.com/spf13/cobra"
+)
+
+// LintCmd creates a new command to run the linters defined in the .devxp config.
+func OwnerCmd(exe utils.Executor, settings *config.Settings) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "owner",
+		Short: "Determines the owner of the specified file.",
+		Args:  cobra.ExactArgs(1),
+		Long: heredoc.Docf(`
+			Determine the owner of the specified file based on the CODEOWNERS file given in the .github directory. If
+			no CODEOWNERS is found in the .github directory, it will return undefined.
+		`, "`"),
+		Example: heredoc.Doc(`
+			// Check the owner of the README.md file
+			$ gh dxp owner README.md
+		`),
+		RunE: func(_ *cobra.Command, args []string) error {
+			path := args[0]
+			return owner.Execute(path)
+		},
+	}
+
+	return cmd
+}

--- a/pkg/cmd/template.go
+++ b/pkg/cmd/template.go
@@ -13,7 +13,7 @@ import (
 )
 
 // TemplateCmd initializes a repository with default files.
-func TemplateCmd(exe utils.Executor, settings *config.Settings) *cobra.Command {
+func TemplateCmd(_ utils.Executor, settings *config.Settings) *cobra.Command {
 	opts := &pr.Options{}
 
 	cmd := &cobra.Command{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,7 +25,7 @@ func ReadConfig(filepath string) (*Settings, error) {
 // DefaultSettings loads the default .devxp settings.
 func DefaultSettings() *Settings {
 	return &Settings{
-		ProjectTemplateUri: "https://raw.githubusercontent.com/elhub/devxp-project-template/main/resources/",
+		ProjectTemplateURI: "https://raw.githubusercontent.com/elhub/devxp-project-template/main/resources/",
 		ProjectType:        "",
 	}
 }
@@ -33,7 +33,7 @@ func DefaultSettings() *Settings {
 // MergeSettings merges two settings.
 func MergeSettings(source *Settings, newSettings *Settings) *Settings {
 	if newSettings.ProjectType != "" {
-		source.ProjectTemplateUri = newSettings.ProjectTemplateUri
+		source.ProjectTemplateURI = newSettings.ProjectTemplateURI
 		source.ProjectType = newSettings.ProjectType
 	}
 

--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -2,6 +2,6 @@ package config
 
 // Settings represents the configuration settings for the gh-dxp extension.
 type Settings struct {
-	ProjectTemplateUri string `yaml:"projectTemplateUri"`
+	ProjectTemplateURI string `yaml:"projectTemplateUri"`
 	ProjectType        string `yaml:"projectType"`
 }

--- a/pkg/owner/owner.go
+++ b/pkg/owner/owner.go
@@ -2,12 +2,14 @@
 package owner
 
 import (
+	"errors"
 	"os"
 
 	"github.com/elhub/gh-dxp/pkg/utils"
 	"github.com/hmarr/codeowners"
 )
 
+// Execute determines the owner of the specified file based on the CODEOWNERS file given in the .github directory.
 func Execute(path string, exe utils.Executor) ([]string, error) {
 	gitRoot, err := utils.GetGitRootDirectory(exe)
 	if err != nil {
@@ -37,4 +39,28 @@ func Execute(path string, exe utils.Executor) ([]string, error) {
 
 	// Return the owners of the file
 	return owners, nil
+}
+
+// GetDefaultFile returns the default file to check for codeowners.
+func GetDefaultFile(exe utils.Executor) (string, error) {
+	rootDir, err := utils.GetGitRootDirectory(exe)
+	if err != nil {
+		return "", err
+	}
+
+	readmeFile := rootDir + "README.md"
+
+	if utils.FileExists(readmeFile) {
+		return readmeFile, nil
+	}
+
+	// Get the first file in the root directory
+	files, err := utils.ListFilesInDirectory(exe, rootDir)
+	if err != nil {
+		return "", err
+	}
+	if len(files) > 0 {
+		return rootDir + files[0], nil
+	}
+	return "", errors.New("no files found in the root directory")
 }

--- a/pkg/owner/owner.go
+++ b/pkg/owner/owner.go
@@ -48,19 +48,11 @@ func GetDefaultFile(exe utils.Executor) (string, error) {
 		return "", err
 	}
 
-	readmeFile := rootDir + "README.md"
+	ownersFile := rootDir + ".github/CODEOWNERS"
 
-	if utils.FileExists(readmeFile) {
-		return readmeFile, nil
+	if utils.FileExists(ownersFile) {
+		return ownersFile, nil
 	}
 
-	// Get the first file in the root directory
-	files, err := utils.ListFilesInDirectory(exe, rootDir)
-	if err != nil {
-		return "", err
-	}
-	if len(files) > 0 {
-		return rootDir + files[0], nil
-	}
-	return "", errors.New("no files found in the root directory")
+	return "", errors.New("could not find CODEOWNERS file in .github directory")
 }

--- a/pkg/owner/owner.go
+++ b/pkg/owner/owner.go
@@ -1,0 +1,28 @@
+package owner
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/hmarr/codeowners"
+)
+
+func Execute(path string) error {
+	codeownersFile, err := os.Open(".github/CODEOWNERS")
+	if err != nil {
+		return err
+	}
+
+	ruleset, err := codeowners.ParseFile(codeownersFile)
+	if err != nil {
+		return err
+	}
+
+	rule, err := ruleset.Match(path)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Owners: %v\n", rule.Owners)
+	return nil
+}

--- a/pkg/owner/owner.go
+++ b/pkg/owner/owner.go
@@ -1,34 +1,40 @@
+// Package owner provides the functionality to get the codeowners of a given path
 package owner
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/elhub/gh-dxp/pkg/utils"
 	"github.com/hmarr/codeowners"
 )
 
-func Execute(path string, exe utils.Executor) error {
+func Execute(path string, exe utils.Executor) ([]string, error) {
 	gitRoot, err := utils.GetGitRootDirectory(exe)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	codeownersFile, err := os.Open(gitRoot + "/.github/CODEOWNERS")
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	ruleset, err := codeowners.ParseFile(codeownersFile)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	rule, err := ruleset.Match(path)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	fmt.Printf("Owners: %v\n", rule.Owners)
-	return nil
+	// Convert rule.Owners to []string
+	owners := make([]string, len(rule.Owners))
+	for i, owner := range rule.Owners {
+		owners[i] = owner.String()
+	}
+
+	// Return the owners of the file
+	return owners, nil
 }

--- a/pkg/owner/owner.go
+++ b/pkg/owner/owner.go
@@ -4,11 +4,17 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/elhub/gh-dxp/pkg/utils"
 	"github.com/hmarr/codeowners"
 )
 
-func Execute(path string) error {
-	codeownersFile, err := os.Open(".github/CODEOWNERS")
+func Execute(path string, exe utils.Executor) error {
+	gitRoot, err := utils.GetGitRootDirectory(exe)
+	if err != nil {
+		return err
+	}
+
+	codeownersFile, err := os.Open(gitRoot + "/.github/CODEOWNERS")
 	if err != nil {
 		return err
 	}

--- a/pkg/owner/owner_test.go
+++ b/pkg/owner/owner_test.go
@@ -1,0 +1,60 @@
+package owner_test
+
+import (
+	"testing"
+
+	"github.com/elhub/gh-dxp/pkg/owner"
+	"github.com/elhub/gh-dxp/pkg/utils"
+	"github.com/stretchr/testify/require"
+)
+
+/*
+type MockExecutor struct {
+	mock.Mock
+}
+
+func (m *MockExecutor) Command(name string, arg ...string) (string, error) {
+	args := m.Called(name, arg)
+	return args.String(0), args.Error(1)
+}
+
+func (m *MockExecutor) CommandContext(ctx context.Context, name string, arg ...string) error {
+	args := m.Called(ctx, name, arg)
+	return args.Error(1)
+}
+
+func (m *MockExecutor) GH(arg ...string) (bytes.Buffer, error) {
+	args := m.Called(arg)
+	return *bytes.NewBufferString(args.String(0)), args.Error(1)
+}
+*/
+
+func TestExecute(t *testing.T) {
+	tests := []struct {
+		path   string
+		owners []string
+	}{
+		{
+			path:   "README.md",
+			owners: []string{"@elhub/devxp"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			/*mockExe := new(MockExecutor)
+
+			mockExe.On("Command", "git", []string{"rev-parse", "--show-toplevel"}).Return(tt.gitRoot, tt.gitRootError)
+			mockExe.On("CommandContext", mock.Anything, "gradlew", []string{"test"}).Return(nil, tt.expectedErr)
+			mockExe.On("CommandContext", mock.Anything, "make", []string{"check"}).Return(nil, tt.expectedErr)
+			mockExe.On("CommandContext", mock.Anything, "npm", []string{"test"}).Return(nil, tt.expectedErr)
+			mockExe.On("CommandContext", mock.Anything, "mvn", []string{"test"}).Return(nil, tt.expectedErr)*/
+
+			exe := utils.LinuxExecutor()
+
+			owners, err := owner.Execute(tt.path, exe)
+			require.NoError(t, err)
+			require.Equal(t, tt.owners, owners)
+		})
+	}
+}

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -2,6 +2,7 @@
 package template
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -11,11 +12,10 @@ import (
 	"github.com/elhub/gh-dxp/pkg/config"
 )
 
+// Execute downloads the project template files and writes them to the working directory.
 func Execute(workingDir string, settings *config.Settings) error {
 	// Get the project template URI
-	uri := settings.ProjectTemplateUri
-
-	// Get the current working directory
+	uri := settings.ProjectTemplateURI
 
 	// Create the .github directory if it does not exist
 	ghDir := filepath.Join(workingDir, ".github")
@@ -80,10 +80,16 @@ func Execute(workingDir string, settings *config.Settings) error {
 	return nil
 }
 
-// Downloads a file from an URI and writes it to path
+// Downloads a file from an URI and writes it to path.
 func writeFile(uri string, filepath string) error {
-	// Get the data
-	resp, err := http.Get(uri)
+	// Create a new request
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, uri, nil)
+	if err != nil {
+		return err
+	}
+
+	// Create a new HTTP client and send the request
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return err
 	}

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -1,4 +1,4 @@
-// Package init provides utilities to set up new repositories
+// Package template provides utilities to set up new repositories using our project template.
 package template
 
 import (

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -18,7 +18,7 @@ func TestExecute(t *testing.T) {
 
 	// Set up the test settings
 	settings := &config.Settings{
-		ProjectTemplateUri: "http://example.com/template/",
+		ProjectTemplateURI: "http://example.com/template/",
 	}
 
 	// Set up the expected file paths
@@ -43,5 +43,4 @@ func TestExecute(t *testing.T) {
 
 	// Clean up the temporary directory
 	os.RemoveAll(tempDir)
-
 }

--- a/pkg/test/test.go
+++ b/pkg/test/test.go
@@ -34,7 +34,7 @@ func RunTest(exe utils.Executor) error {
 }
 
 func resolveTestCommand(exe utils.Executor) (string, []string, error) {
-	root, err := getGitRootDirectory(exe)
+	root, err := utils.GetGitRootDirectory(exe)
 	if err != nil {
 		return "", nil, err
 	}

--- a/pkg/test/test.go
+++ b/pkg/test/test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/elhub/gh-dxp/pkg/utils"
 )
 
-// FileExists checks to see whether a file exists in the file system. Exported to allow mocking during tests.
-var FileExists = utils.FileExists
+// FileExists checks to see whether a file exists in the file system.
+var FileExists = utils.FileExists //nolint: gochecknoglobals // Exported to allow mocking during tests.
 
 // RunTest runs a workflow to automatically determine relevant tests in the current repo and run them.
 func RunTest(exe utils.Executor) error {

--- a/pkg/test/test.go
+++ b/pkg/test/test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/caarlos0/log"
 	"github.com/elhub/gh-dxp/pkg/utils"
@@ -56,18 +55,6 @@ func resolveTestCommand(exe utils.Executor) (string, []string, error) {
 	return "", []string{}, &NoTestCommandError{Msg: "No test command found"}
 }
 
-func getGitRootDirectory(exe utils.Executor) (string, error) {
-	// Locate the root directory of current git repo
-	// Fails if not in a repo
-
-	root, err := exe.Command("git", "rev-parse", "--show-toplevel")
-	if err != nil {
-		return "", &NotAGitRepoError{Msg: "Not a git repo"}
-	}
-
-	return strings.TrimSuffix(root, "\n"), nil
-}
-
 func gradleTestInGitRoot(root string) bool {
 	return FileExists(fmt.Sprintf("%s/gradlew", root))
 }
@@ -87,16 +74,6 @@ func npmTestInGitRoot(root string) bool {
 // NoTestCommandError signifies that no valid test command was found in the current git repo.
 type NoTestCommandError struct {
 	Msg string
-}
-
-// NotAGitRepoError signifies that the current working directory is not a git repo.
-type NotAGitRepoError struct {
-	Msg string
-}
-
-// Signifies that the current working directory is not a git repo.
-func (e *NotAGitRepoError) Error() string {
-	return e.Msg
 }
 
 // Signifies that no valid test command was found in the current git repo.

--- a/pkg/utils/directory.go
+++ b/pkg/utils/directory.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 )
 
+// GetGitRootDirectory returns the root directory of the current git repo.
 func GetGitRootDirectory(exe Executor) (string, error) {
 	// Locate the root directory of current git repo
 	// Fails if not in a repo
@@ -26,6 +27,7 @@ func (e *NotAGitRepoError) Error() string {
 	return e.Msg
 }
 
+// ListFilesInDirectory returns a list of files in a given directory.
 func ListFilesInDirectory(exe Executor, directory string) ([]string, error) {
 	// List all files in a directory
 	// Fails if directory does not exist

--- a/pkg/utils/directory.go
+++ b/pkg/utils/directory.go
@@ -25,3 +25,15 @@ type NotAGitRepoError struct {
 func (e *NotAGitRepoError) Error() string {
 	return e.Msg
 }
+
+func ListFilesInDirectory(exe Executor, directory string) ([]string, error) {
+	// List all files in a directory
+	// Fails if directory does not exist
+
+	files, err := exe.Command("ls", directory)
+	if err != nil {
+		return nil, err
+	}
+
+	return strings.Split(files, "\n"), nil
+}

--- a/pkg/utils/directory.go
+++ b/pkg/utils/directory.go
@@ -1,0 +1,27 @@
+package utils
+
+import (
+	"strings"
+)
+
+func GetGitRootDirectory(exe Executor) (string, error) {
+	// Locate the root directory of current git repo
+	// Fails if not in a repo
+
+	root, err := exe.Command("git", "rev-parse", "--show-toplevel")
+	if err != nil {
+		return "", &NotAGitRepoError{Msg: "Not a git repo"}
+	}
+
+	return strings.TrimSuffix(root, "\n"), nil
+}
+
+// NotAGitRepoError signifies that the current working directory is not a git repo.
+type NotAGitRepoError struct {
+	Msg string
+}
+
+// Signifies that the current working directory is not a git repo.
+func (e *NotAGitRepoError) Error() string {
+	return e.Msg
+}


### PR DESCRIPTION
Summary:
- Adds codeowners parsing to gh-dxp functionality.
- Updates the project template files. Project template files need to be updated for testing to work.
- Cleared out some linting issues not properly handled as they blocked this commit being clean.

Issue ID(s): TDX-522

Testing:
- [X] Unit Tests
- [ ] Integration Tests
- Test Command: make check


Documentation:
- No updates
