### PR TITLE
Save last process exit code as separate variable before evaluating [patch]

### DIFF
--- a/build_release_version.sh
+++ b/build_release_version.sh
@@ -18,8 +18,10 @@ compile() {
   echo "Building for ${GOOS}/${GOARCH}..."
 
   GOOS=${GOOS} GOARCH=${GOARCH} go build -o "${OUTPUT}" .
+
+  EXIT_CODE=$?
   
-  if ! GOOS; then
+  if [ $EXIT_CODE -ne 0 ]; then
     echo "Error building for ${GOOS}/${GOARCH}"
     exit 1
   fi


### PR DESCRIPTION
Summary:
This handles both the lint error prompting the previous change and also (hopefully) a working plugin build

Testing:
- [ ] Unit Tests
- [ ] Integration Tests
- Test Command: 


Documentation:
- No updates
