### PR TITLE
Display correct version when invoking the -v flag [patch]

### DIFF
--- a/build_release_version.sh
+++ b/build_release_version.sh
@@ -2,6 +2,9 @@
 
 # Set the plugin name
 PLUGIN_NAME="gh-dxp"
+PLUGIN_VERSION=$1
+
+echo "Building as version $PLUGIN_VERSION"
 
 # Create the dist directory if it doesn't exist
 mkdir -p dist
@@ -16,8 +19,7 @@ compile() {
   local OUTPUT="dist/${PLUGIN_NAME}-${GOOS}-${GOARCH}"
 
   echo "Building for ${GOOS}/${GOARCH}..."
-
-  GOOS=${GOOS} GOARCH=${GOARCH} go build -o "${OUTPUT}" .
+  GOOS=${GOOS} GOARCH=${GOARCH} go build -ldflags="-X 'main.version=${PLUGIN_VERSION}'" -o "${OUTPUT}" .
 
   EXIT_CODE=$?
   

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	version = "0.1.0"
+	version = "locally compiled development build"
 )
 
 func main() {


### PR DESCRIPTION
Summary:
This change injects the version tag into the release binaries so that the correct version is displayed when invoking the --version flag. If built locally, the plugin will state this clearly as well.
Issue ID(s): TDX-536

Testing:
- [ ] Unit Tests
- [ ] Integration Tests
- Test Command: 


Documentation:
- No updates
