### PR TITLE
add nolint and nounit options to pr flow [minor]

### DIFF
--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -52,7 +52,7 @@ func GenerateCmd(settings *config.Settings, version string) *cobra.Command {
 		LintCmd(exe, settings),
 		MergeCmd(exe),
 		OwnerCmd(exe, settings),
-		PRCmd(exe),
+		PRCmd(exe, settings),
 		TestCmd(exe),
 		TemplateCmd(exe, settings),
 	)

--- a/pkg/cmd/pr.go
+++ b/pkg/cmd/pr.go
@@ -2,13 +2,14 @@ package cmd
 
 import (
 	"github.com/MakeNowJust/heredoc"
+	"github.com/elhub/gh-dxp/pkg/config"
 	"github.com/elhub/gh-dxp/pkg/pr"
 	"github.com/elhub/gh-dxp/pkg/utils"
 	"github.com/spf13/cobra"
 )
 
 // PRCmd handles the creation of a pull request.
-func PRCmd(exe utils.Executor) *cobra.Command {
+func PRCmd(exe utils.Executor, settings *config.Settings) *cobra.Command {
 	opts := &pr.Options{}
 
 	cmd := &cobra.Command{
@@ -27,7 +28,7 @@ func PRCmd(exe utils.Executor) *cobra.Command {
 		Aliases: []string{"diff"},
 		Args:    cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			return pr.Execute(exe, opts)
+			return pr.Execute(exe, settings, opts)
 		},
 	}
 
@@ -53,6 +54,18 @@ func PRCmd(exe utils.Executor) *cobra.Command {
 		"a",
 		nil,
 		"Assign people by their id. Use \"@me\" to self-assign.",
+	)
+	fl.BoolVar(
+		&opts.NoUnit,
+		"nounit",
+		false,
+		"Do not run tests",
+	)
+	fl.BoolVar(
+		&opts.NoLint,
+		"nolint",
+		false,
+		"Do not run linting",
 	)
 
 	return cmd

--- a/pkg/pr/model.go
+++ b/pkg/pr/model.go
@@ -3,6 +3,8 @@ package pr
 // Options represents the options for the pr command.
 type Options struct {
 	AutoConfirm bool
+	NoLint      bool
+	NoUnit      bool
 
 	baseBranch string
 

--- a/pkg/pr/pr.go
+++ b/pkg/pr/pr.go
@@ -248,6 +248,12 @@ func createBody(options *Options, commits string) (string, error) {
 
 	// TODO: Auto-Linting. If not auto-linted, ask why?
 	// TODO: Auto-Testing. If not auto-tested, ask why?
+	if options.NoUnit {
+		body = addDocSection(body, "🚩🚩🚩 **This PR has not been unit tested!**")
+	}
+	if options.NoLint {
+		body = addDocSection(body, "🚩🚩🚩 **This PR has not been linted!**")
+	}
 
 	testSection, err := testingChanges(options)
 	if err != nil {

--- a/pkg/pr/pr.go
+++ b/pkg/pr/pr.go
@@ -9,13 +9,15 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/caarlos0/log"
 	"github.com/elhub/gh-dxp/pkg/branch"
+	"github.com/elhub/gh-dxp/pkg/config"
+	"github.com/elhub/gh-dxp/pkg/lint"
 	"github.com/elhub/gh-dxp/pkg/test"
 	"github.com/elhub/gh-dxp/pkg/utils"
 	"github.com/pkg/errors"
 )
 
 // Execute creates or updates a pull request, depending on its current state.
-func Execute(exe utils.Executor, options *Options) error {
+func Execute(exe utils.Executor, settings *config.Settings, options *Options) error {
 	// Get branchID
 	currentBranch, errBranch := exe.Command("git", "branch", "--show-current")
 	if errBranch != nil {
@@ -29,6 +31,11 @@ func Execute(exe utils.Executor, options *Options) error {
 		return errCheck
 	}
 
+	err := performPreCommitOperations(exe, settings, options)
+	if err != nil {
+		return err
+	}
+
 	if prID != "" {
 		// If the PR exists, update it by pushing to the remote
 		return update(exe, branchID, prID)
@@ -37,7 +44,7 @@ func Execute(exe utils.Executor, options *Options) error {
 	return create(exe, options, branchID)
 }
 
-func create(exe utils.Executor, options *Options, branchID string) error {
+func performPreCommitOperations(exe utils.Executor, settings *config.Settings, options *Options) error {
 	// Handle uncommitted changes
 	err := handleUncommittedChanges(exe, options)
 	if err != nil {
@@ -45,11 +52,25 @@ func create(exe utils.Executor, options *Options, branchID string) error {
 	}
 
 	// Run tests
-	err = test.RunTest(exe)
-	if err != nil {
-		return err
+	if !options.NoUnit {
+		err = test.RunTest(exe)
+		if err != nil {
+			return err
+		}
 	}
 
+	// Run lint
+	if !options.NoLint {
+		err = lint.Run(exe, settings)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func create(exe utils.Executor, options *Options, branchID string) error {
 	// Push the current branch to git remote
 	s := utils.StartSpinner("Pushing current branch to remote...", "Pushed working branch to remote.")
 	currentBranch, err := exe.Command("git", "push", "--set-upstream", "origin", branchID)
@@ -103,15 +124,9 @@ func generatePRArgs(options *Options) []string {
 }
 
 func update(exe utils.Executor, branchID string, prID string) error {
-	// Run tests
-	err := test.RunTest(exe)
-	if err != nil {
-		return err
-	}
-
 	// Push the current branch to the already existing git remote
 	s := utils.StartSpinner("Updating Pull Request #"+prID+"...", "Pull Request #"+prID+" has been updated.")
-	_, err = exe.Command("git", "push")
+	_, err := exe.Command("git", "push")
 	s.Stop()
 	if err != nil {
 		return err

--- a/pkg/pr/pr_test.go
+++ b/pkg/pr/pr_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/elhub/gh-dxp/pkg/config"
 	"github.com/elhub/gh-dxp/pkg/pr"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -50,6 +51,7 @@ func TestExecute(t *testing.T) {
 		prCreateErr      error
 		expectedErr      error
 		currentChanges   string
+		expectedLintErr  error
 	}{
 		{
 			name:           "Test successful PR creation",
@@ -167,6 +169,11 @@ func TestExecute(t *testing.T) {
 			expectedErr:    nil,
 			currentChanges: " M tracked_change.go",
 		},
+		{
+			name:            "Test lint is failing",
+			expectedLintErr: errors.New("exit status 1"),
+			expectedErr:     errors.New("exit status 1"),
+		},
 	}
 
 	for _, tt := range tests {
@@ -176,6 +183,10 @@ func TestExecute(t *testing.T) {
 			mockExe.On("Command", "git", []string{"status", "--porcelain"}).Return(tt.currentChanges, nil)
 			mockExe.On("Command", "git", []string{"branch", "--show-current"}).Return(tt.currentBranch, tt.currentBranchErr)
 			mockExe.On("Command", "git", []string{"push"}).Return(tt.pushBranch, tt.pushBranchErr)
+			mockExe.On("CommandContext", mock.Anything, "npx",
+				[]string{"mega-linter-runner", "--flavor", "cupcake", "-e",
+					"MEGALINTER_CONFIG=https://raw.githubusercontent.com/elhub/devxp-lint-configuration/main/resources/.mega-linter.yml"}).
+				Return("", tt.expectedLintErr)
 			mockExe.On("Command", "git", []string{"push", "--set-upstream", "origin", tt.currentBranch}).
 				Return(tt.pushBranch, tt.pushBranchErr)
 			mockExe.On("Command", "git", []string{"log", "main.." + tt.currentBranch, "--oneline", "--pretty=format:%s"}).
@@ -190,9 +201,11 @@ func TestExecute(t *testing.T) {
 			mockExe.On("GH", []string{"repo", "view", "--json", "defaultBranchRef", "--jq", ".defaultBranchRef.name"}).
 				Return(tt.repoBranchName, tt.repoBranchErr)
 
-			err := pr.Execute(mockExe, &pr.Options{
-				AutoConfirm: true,
-			})
+			err := pr.Execute(mockExe,
+				&config.Settings{},
+				&pr.Options{
+					AutoConfirm: true,
+				})
 
 			if tt.expectedErr != nil {
 				require.Error(t, err)


### PR DESCRIPTION
This diff adds optional --nounit and --nolint flags to disable tests and linting respectively. If the flags are activated on PR creation (i.e., not update), some "red flags" will be displayed in the PR summary.


Issue ID(s): TDX-530

Testing:
- [x] Unit Tests
- [ ] Integration Tests
- Test Command: 


Documentation:
- No updates
