### PR TITLE
Delete local branch and change to main also if merge has already been performed in remote [patch]

### DIFF
--- a/pkg/merge/merge.go
+++ b/pkg/merge/merge.go
@@ -49,7 +49,7 @@ func Execute(exe utils.Executor, options *Options) error {
 		return nil
 	}
 
-	stdOut, err := exe.GH("pr", "merge", "--squash", "--auto", "--delete-branch")
+	stdOut, err := exe.GH("pr", "merge", "--squash", "--delete-branch")
 	log.Info(stdOut.String())
 
 	if err != nil {

--- a/pkg/merge/merge_test.go
+++ b/pkg/merge/merge_test.go
@@ -88,7 +88,7 @@ func TestExecute(t *testing.T) {
 			mockExe.On("GH", []string{"pr", "list", "-H", tt.pushBranch, "--json", "number", "--jq", ".[].number"}).
 				Return(tt.prNumber, tt.prNumberErr)
 			mockExe.On("GH", []string{"pr", "view", "--json", "title", "--jq", ".title"}).Return(tt.prTitle, tt.prTitleErr)
-			mockExe.On("GH", []string{"pr", "merge", "--squash", "--auto", "--delete-branch"}).Return(tt.prMerge, tt.prMergeErr)
+			mockExe.On("GH", []string{"pr", "merge", "--squash", "--delete-branch"}).Return(tt.prMerge, tt.prMergeErr)
 
 			err := merge.Execute(mockExe, &merge.Options{
 				AutoConfirm: true,


### PR DESCRIPTION
Summary:
This change removes the --auto from the merge command, as it was causing the dxp merge command to not properly delete the local branch and change back to main if the relevant PR has already been merged in remote.
Issue ID(s): TDX-559

Testing:
- [ ] Unit Tests
- [ ] Integration Tests


Documentation:
- No updates
