### PR TITLE
Run (almost) all commands from git repo root directory [patch]

### DIFF
--- a/pkg/cmd/branch.go
+++ b/pkg/cmd/branch.go
@@ -22,6 +22,10 @@ func BranchCmd(exe utils.Executor) *cobra.Command {
 			$ gh dxp branch wip
 		`),
 		RunE: func(_ *cobra.Command, args []string) error {
+			err := utils.SetWorkDirToGitHubRoot(exe)
+			if err != nil {
+				return err
+			}
 			branchID := args[0]
 
 			s := utils.StartSpinner("Creating new work branch...", "Work Branch "+branchID)

--- a/pkg/cmd/lint.go
+++ b/pkg/cmd/lint.go
@@ -27,6 +27,10 @@ func LintCmd(exe utils.Executor, settings *config.Settings) *cobra.Command {
 			$ gh dxp lint --all
 		`),
 		RunE: func(_ *cobra.Command, _ []string) error {
+			err := utils.SetWorkDirToGitHubRoot(exe)
+			if err != nil {
+				return err
+			}
 			return lint.Run(exe, settings, opts)
 		},
 	}

--- a/pkg/cmd/merge.go
+++ b/pkg/cmd/merge.go
@@ -26,10 +26,11 @@ func MergeCmd(exe utils.Executor) *cobra.Command {
 		Aliases: []string{"land"},
 		Args:    cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			_, err := utils.IsInGitHubRepo(exe)
+			err := utils.SetWorkDirToGitHubRoot(exe)
 			if err != nil {
 				return err
 			}
+
 			return merge.Execute(exe, opts)
 		},
 	}

--- a/pkg/cmd/pr.go
+++ b/pkg/cmd/pr.go
@@ -28,7 +28,7 @@ func PRCmd(exe utils.Executor, settings *config.Settings) *cobra.Command {
 		Aliases: []string{"diff"},
 		Args:    cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			_, err := utils.IsInGitHubRepo(exe)
+			err := utils.SetWorkDirToGitHubRoot(exe)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/status.go
+++ b/pkg/cmd/status.go
@@ -31,7 +31,7 @@ func StatusCmd(exe utils.Executor) *cobra.Command {
         `),
 		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			_, err := utils.IsInGitHubRepo(exe)
+			err := utils.SetWorkDirToGitHubRoot(exe)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/test.go
+++ b/pkg/cmd/test.go
@@ -16,6 +16,10 @@ func TestCmd(exe utils.Executor) *cobra.Command {
 		Long: heredoc.Docf(`
 			Run tests based on project type`, "`"),
 		RunE: func(_ *cobra.Command, _ []string) error {
+			err := utils.SetWorkDirToGitHubRoot(exe)
+			if err != nil {
+				return err
+			}
 			res := test.RunTest(exe)
 			return res
 		},

--- a/pkg/lint/model.go
+++ b/pkg/lint/model.go
@@ -2,6 +2,6 @@ package lint
 
 // Options represents the options for the lint command.
 type Options struct {
+	Fix     bool
 	LintAll bool
-	Fix bool
 }

--- a/pkg/utils/directory.go
+++ b/pkg/utils/directory.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"os"
 	"strings"
 )
 
@@ -16,6 +17,27 @@ func GetGitRootDirectory(exe Executor) (string, error) {
 	formattedRoot := strings.TrimSuffix(root, "\n")
 
 	return formattedRoot, nil
+}
+
+// SetWorkDirToGitHubRoot checks whether the current working directory is in a GitHub repo. If false, an error is raised. If true, the working directory is set to the root of that repo.
+func SetWorkDirToGitHubRoot(exe Executor) error {
+	_, err := isInGitHubRepo(exe)
+	if err != nil {
+		return err
+	}
+	err = setWorkingDirectoryToGitRoot(exe)
+	return err
+}
+
+// setWorkingDirectoryToGitRoot sets the working directory to be the git root directory.
+func setWorkingDirectoryToGitRoot(exe Executor) error {
+	root, err := GetGitRootDirectory(exe)
+	if err != nil {
+		return err
+	}
+
+	err = os.Chdir(root)
+	return err
 }
 
 // NotAGitRepoError signifies that the current working directory is not a git repo.
@@ -51,8 +73,8 @@ func ListFilesInDirectory(exe Executor, directory string) ([]string, error) {
 	return strings.Split(files, "\n"), nil
 }
 
-// IsInGitHubRepo checks whether the current working directory is in a GitHub repo.
-func IsInGitHubRepo(exe Executor) (bool, error) {
+// isInGitHubRepo checks whether the current working directory is in a GitHub repo.
+func isInGitHubRepo(exe Executor) (bool, error) {
 	url, err := exe.Command("git", "remote", "get-url", "origin")
 
 	if err != nil {
@@ -62,7 +84,7 @@ func IsInGitHubRepo(exe Executor) (bool, error) {
 		return false, &NotAGitHubRepoError{Msg: "Current origin is not a GitHub repository"}
 	}
 
-	return false, nil
+	return true, nil
 }
 
 func urlIsGitHubRepo(url string) bool {


### PR DESCRIPTION
Summary:
Originally, this diff was only intended to change the working directory on lint. However, this has interactions with the PR command as well, so I decided to try running pretty much everything from the git root instead. We'll see if it works out.

Testing:
- [ ] Unit Tests
- [ ] Integration Tests


Documentation:
- No updates
