### PR TITLE
rename AutoConfirm to TestRun and remove it from command options [patch]

### DIFF
--- a/pkg/cmd/pr.go
+++ b/pkg/cmd/pr.go
@@ -38,13 +38,6 @@ func PRCmd(exe utils.Executor, settings *config.Settings) *cobra.Command {
 
 	// TODO: Support flags from gh pr
 	fl := cmd.Flags()
-	fl.BoolVarP(
-		&opts.AutoConfirm,
-		"confirm",
-		"y",
-		false,
-		"Don't ask for user input.",
-	)
 	fl.StringSliceVarP(
 		&opts.Reviewers,
 		"reviewer",

--- a/pkg/cmd/template.go
+++ b/pkg/cmd/template.go
@@ -40,7 +40,7 @@ func TemplateCmd(_ utils.Executor, settings *config.Settings) *cobra.Command {
 	// TODO: Support flags from gh pr
 	fl := cmd.Flags()
 	fl.BoolVarP(
-		&opts.AutoConfirm,
+		&opts.TestRun,
 		"confirm",
 		"y",
 		false,

--- a/pkg/pr/model.go
+++ b/pkg/pr/model.go
@@ -2,9 +2,9 @@ package pr
 
 // Options represents the options for the pr command.
 type Options struct {
-	AutoConfirm bool
-	NoLint      bool
-	NoUnit      bool
+	TestRun bool
+	NoLint  bool
+	NoUnit  bool
 
 	Branch        string
 	CommitMessage string

--- a/pkg/pr/pr.go
+++ b/pkg/pr/pr.go
@@ -209,7 +209,7 @@ func createPR(
 
 	// Get the title
 	pr.Title = getDefaultTitle(commits)
-	if !options.AutoConfirm {
+	if !options.TestRun {
 		pr.Title, err = askForString("Title", pr.Title)
 		if err != nil {
 			return pr, err
@@ -244,7 +244,7 @@ func createBody(options *Options, commits string) (string, error) {
 		bodySurvey = "Do you want to change the summary?"
 	}
 
-	if !options.AutoConfirm {
+	if !options.TestRun {
 		editBody, err := askToConfirm(bodySurvey)
 		if err != nil {
 			return "", err
@@ -299,7 +299,7 @@ func issuesChanges(options *Options) (string, error) {
 	// Issue ID(s)
 	// Optionally add the issue ID(s) to the PR body.
 	body := ""
-	if !options.AutoConfirm {
+	if !options.TestRun {
 		issueIDString, errI := askForString("Issue IDs (seperate with commas):", "")
 		if errI != nil {
 			return "", errI
@@ -326,7 +326,7 @@ func testingChanges(options *Options) (string, error) {
 	// TODO: Consider skipping this, if dealing with code where unit and integration
 	// tests are not applicable. Replace with deploy test question?
 	body := ""
-	if !options.AutoConfirm {
+	if !options.TestRun {
 		unitTestConfirm, err := askToConfirm("Did you add new unit tests?")
 		if err != nil {
 			return "", err
@@ -356,7 +356,7 @@ func handleUncommittedChanges(exe utils.Executor, options *Options) ([]string, e
 		return []string{}, err
 	}
 
-	if len(untrackedChanges) > 0 && !options.AutoConfirm {
+	if len(untrackedChanges) > 0 && !options.TestRun {
 		res, err := askToConfirm(formatUntrackedFileChangesQuestion(untrackedChanges))
 		if err != nil {
 			return []string{}, err
@@ -372,7 +372,7 @@ func handleUncommittedChanges(exe utils.Executor, options *Options) ([]string, e
 		return []string{}, err
 	}
 
-	if len(trackedChanges) > 0 && !options.AutoConfirm {
+	if len(trackedChanges) > 0 && !options.TestRun {
 		res, err := askToConfirm(formatTrackedFileChangesQuestion(trackedChanges))
 		if err != nil {
 			return []string{}, err
@@ -390,7 +390,7 @@ func documentationChanges(options *Options) (string, error) {
 	// Multi-choice: README.md, docs, storybook, no updates
 	docOptions := []string{"No updates", "README.md", "docs", "storybook"}
 	selectedDocs := []string{}
-	if !options.AutoConfirm {
+	if !options.TestRun {
 		err := survey.AskOne(&survey.MultiSelect{
 			Message: "What documentation was updated?",
 			Options: docOptions,
@@ -519,7 +519,7 @@ func addAndCommitFiles(exe utils.Executor, files []string, options *Options) err
 		commitMessage = options.CommitMessage
 	} else {
 
-		if !options.AutoConfirm {
+		if !options.TestRun {
 			commitMessage, err = askForString("Please enter a commit message: ", "")
 			if err != nil {
 				return err
@@ -589,7 +589,7 @@ func getNewBranchName(options *Options) (string, error) {
 		return options.Branch, nil
 	}
 
-	if !options.AutoConfirm {
+	if !options.TestRun {
 		inputBranchName, err := askForString("You are currently on the base branch. Please specify a temporary branch name: ", "")
 		if err != nil {
 			return "", err

--- a/pkg/pr/pr_test.go
+++ b/pkg/pr/pr_test.go
@@ -241,7 +241,7 @@ func TestExecute(t *testing.T) {
 			err := pr.Execute(mockExe,
 				&config.Settings{},
 				&pr.Options{
-					AutoConfirm: true,
+					TestRun: true,
 				})
 
 			if tt.expectedErr != nil {


### PR DESCRIPTION
Testing:
- [ ] Unit Tests
- [ ] Integration Tests


Documentation:
- No updates
