### PR TITLE
bypass untracked changes confirmation prompt if commit message option is specified [patch]

### DIFF
--- a/pkg/pr/pr.go
+++ b/pkg/pr/pr.go
@@ -372,7 +372,7 @@ func handleUncommittedChanges(exe utils.Executor, options *Options) ([]string, e
 		return []string{}, err
 	}
 
-	if len(trackedChanges) > 0 && !options.TestRun {
+	if len(trackedChanges) > 0 && !options.TestRun && options.CommitMessage == "" {
 		res, err := askToConfirm(formatTrackedFileChangesQuestion(trackedChanges))
 		if err != nil {
 			return []string{}, err


### PR DESCRIPTION
This change should've been included in the original feature, probably, as it doesn't make much sense to prompt the user for whether they'd like to create a new commit if they've already specified a commit message

Testing:
- [ ] Unit Tests
- [ ] Integration Tests


Documentation:
- No updates
