### PR TITLE
handle file renames [patch]

### DIFF
--- a/pkg/prcreate/prcreate_test.go
+++ b/pkg/prcreate/prcreate_test.go
@@ -211,6 +211,20 @@ func TestExecute(t *testing.T) {
 			currentChanges:   " M tracked_change.go\n M tracked_change2.go",
 		},
 		{
+			name:             "Test local has a file rename",
+			currentBranch:    "branch1",
+			pushBranch:       "branch1",
+			prListNumber:     "",
+			prListNErr:       nil,
+			prListURL:        "https://github.com/elhub/demo/pull/3",
+			gitLog:           "commit 1",
+			repoBranchName:   "main",
+			prCreate:         "pull request created",
+			expectedErr:      nil,
+			existingBranches: "main\ndifferentBranch\n",
+			currentChanges:   " M tracked_change.go\n M tracked_change2.go\nR  oldname.go -> newname.go",
+		},
+		{
 			name:             "Test lint is failing",
 			expectedLintErr:  errors.New("exit status 1"),
 			expectedErr:      errors.New("exit status 1"),
@@ -237,6 +251,7 @@ func TestExecute(t *testing.T) {
 			mockExe.On("Command", "git", []string{"branch"}).Return(tt.existingBranches, nil)
 			mockExe.On("Command", "git", []string{"add", "/home/repo-name/tracked_change.go"}).Return("", nil)
 			mockExe.On("Command", "git", []string{"add", "/home/repo-name/tracked_change.go", "/home/repo-name/tracked_change2.go"}).Return("", nil)
+			mockExe.On("Command", "git", []string{"add", "/home/repo-name/tracked_change.go", "/home/repo-name/tracked_change2.go", "/home/repo-name/newname.go"}).Return("", nil)
 			mockExe.On("Command", "git", []string{"commit", "-m", "default commit message"}).Return("", nil)
 			mockExe.On("Command", "git", []string{"show-ref", "--verify", "--quiet", "refs/heads/" + tt.currentBranch})
 			mockExe.On("CommandContext", mock.Anything, "npx", linterArgs).Return("", tt.expectedLintErr)

--- a/pkg/utils/directory.go
+++ b/pkg/utils/directory.go
@@ -95,6 +95,7 @@ func GetTrackedChanges(exe Executor) ([]string, error) {
 	return getChanges(exe, re)
 }
 
+// Checks the current repo state for any changes matching a given regex 're'
 func getChanges(exe Executor, re *regexp.Regexp) ([]string, error) {
 	changeString, err := exe.Command("git", "status", "--porcelain")
 	if err != nil {
@@ -109,6 +110,11 @@ func getChanges(exe Executor, re *regexp.Regexp) ([]string, error) {
 		matchedChanges[i] = re.ReplaceAllString(s, "")
 	}
 
+	// Split string on '->' and capture the last element, in order to catch changes of type 'oldfilename.txt -> newfilename.txt'
+	for i, s := range matchedChanges {
+		macgyver := strings.Split(s, "->")
+		matchedChanges[i] = strings.TrimSpace(macgyver[len(macgyver)-1])
+	}
 	return matchedChanges, nil
 }
 


### PR DESCRIPTION
Summary:
when using 'git mv' to rename files (and perhaps other situations as well), git status will show the file as renamed as opposed to the more usual "old file deleted, new file created". This caused a bug where the pr command was trying to git add a string on the form "oldname.txt -> newname.txt". This change parses these lines so that the new name is included rather than the entire string.

Testing:
- [x] Unit Tests
- [ ] Integration Tests


Documentation:
- No updates
