### PR TITLE
Make 'no test command found' logging statement a bit more verbose [patch]

### DIFF
--- a/pkg/test/test.go
+++ b/pkg/test/test.go
@@ -52,7 +52,7 @@ func resolveTestCommand(exe utils.Executor) (string, []string, error) {
 	if npmTestInGitRoot(root) {
 		return "npm", []string{"test"}, nil
 	}
-	return "", []string{}, &NoTestCommandError{Msg: "No test command found"}
+	return "", []string{}, &NoTestCommandError{Msg: "No test command could be automatically detected. If you want to automatically run tests as part of pr creation, please have a look at the documentation."}
 }
 
 func gradleTestInGitRoot(root string) bool {


### PR DESCRIPTION
Several users have perceived the previous warning as an error, believing that to be the cause of whatever is blocking their commits. This change aims to make it more clear that it is in fact not an error, and also to help them set up testing.

Testing:
- [ ] Unit Tests
- [ ] Integration Tests


Documentation:
- No updates
