### PR TITLE
Allow user to specify a custom linter image [minor]

### DIFF
--- a/pkg/cmd/lint.go
+++ b/pkg/cmd/lint.go
@@ -87,6 +87,13 @@ func LintCmd(exe utils.Executor, settings *config.Settings) *cobra.Command {
 		"",
 		"Lint all files under the given directory",
 	)
+	fl.StringVarP(
+		&opts.LinterImage,
+		"image",
+		"i",
+		"",
+		"Specify which MegaLinter image to use.",
+	)
 
 	return cmd
 }

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -17,7 +17,13 @@ func Run(exe utils.Executor, _ *config.Settings, opts *Options) error {
 	// Run mega-linter-runner with the cupcake flavor.
 	ctx := context.Background()
 
-	args := []string{"npx", "mega-linter-runner", "--flavor", "cupcake"}
+	args := []string{"npx", "mega-linter-runner"}
+
+	if opts.LinterImage == "" {
+		args = append(args, "--flavor", "cupcake")
+	} else {
+		args = append(args, "--image", opts.LinterImage)
+	}
 
 	// Check if mega-lint configuration is present in the repository.
 	if !utils.FileExists(".mega-linter.yml") {

--- a/pkg/lint/model.go
+++ b/pkg/lint/model.go
@@ -2,7 +2,8 @@ package lint
 
 // Options represents the options for the lint command.
 type Options struct {
-	Fix       bool
-	LintAll   bool
-	Directory string
+	Fix         bool
+	LintAll     bool
+	Directory   string
+	LinterImage string
 }


### PR DESCRIPTION
Because of networking constraints on build agents, one might need to specify a different routing for the image than the default. This adds support for that.

Testing:
- [ ] Unit Tests
- [ ] Integration Tests


Documentation:
- No updates
