### PR TITLE
Refactor common code in gh-dxp

### DIFF
--- a/pkg/branch/branch_test.go
+++ b/pkg/branch/branch_test.go
@@ -1,34 +1,13 @@
 package branch_test
 
 import (
-	"bytes"
-	"context"
 	"os/exec"
 	"testing"
 
 	"github.com/elhub/gh-dxp/pkg/branch"
-	"github.com/stretchr/testify/mock"
+	"github.com/elhub/gh-dxp/pkg/testutils"
 	"github.com/stretchr/testify/require"
 )
-
-type MockExecutor struct {
-	mock.Mock
-}
-
-func (m *MockExecutor) Command(name string, args ...string) (string, error) {
-	argsCalled := m.Called(name, args)
-	return argsCalled.String(0), argsCalled.Error(1)
-}
-
-func (m *MockExecutor) CommandContext(ctx context.Context, name string, arg ...string) error {
-	args := m.Called(ctx, name, arg)
-	return args.Error(1)
-}
-
-func (m *MockExecutor) GH(arg ...string) (bytes.Buffer, error) {
-	args := m.Called(arg)
-	return *bytes.NewBufferString(args.String(0)), args.Error(1)
-}
 
 type FakeExitError struct {
 	code int
@@ -45,7 +24,7 @@ func (f FakeExitError) ExitCode() int {
 // This tests both branch.CheckoutBranch and branch.BranchExists.
 func TestCheckoutBranch(t *testing.T) {
 	t.Run("should checkout to existing branch", func(t *testing.T) {
-		mockExec := new(MockExecutor)
+		mockExec := new(testutils.MockExecutor)
 
 		// Set up expectation
 		mockExec.On("Command", "git", []string{"checkout", "existing-branch"}).Return("", nil)
@@ -61,7 +40,7 @@ func TestCheckoutBranch(t *testing.T) {
 	})
 
 	t.Run("should checkout to new branch if it does not exist", func(t *testing.T) {
-		mockExec := new(MockExecutor)
+		mockExec := new(testutils.MockExecutor)
 
 		// Start a process that will exit with code 1
 		// Mocking a os.ProcessState is not possible, so we need to mock the ExitError
@@ -82,7 +61,7 @@ func TestCheckoutBranch(t *testing.T) {
 	})
 
 	t.Run("should throw error if checkout fails to existing branch", func(t *testing.T) {
-		mockExec := new(MockExecutor)
+		mockExec := new(testutils.MockExecutor)
 
 		// Start a process that will exit with code 1
 		// Mocking a os.ProcessState is not possible, so we need to mock the ExitError
@@ -104,7 +83,7 @@ func TestCheckoutBranch(t *testing.T) {
 	})
 
 	t.Run("should throw error if checkout fails to new branch", func(t *testing.T) {
-		mockExec := new(MockExecutor)
+		mockExec := new(testutils.MockExecutor)
 
 		// Start a process that will exit with code 1
 		// Mocking a os.ProcessState is not possible, so we need to mock the ExitError
@@ -126,7 +105,7 @@ func TestCheckoutBranch(t *testing.T) {
 	})
 
 	t.Run("should throw error if branch exists check fails", func(t *testing.T) {
-		mockExec := new(MockExecutor)
+		mockExec := new(testutils.MockExecutor)
 
 		// Set up expectation
 		mockExec.On("Command", "git", []string{"show-ref", "--verify", "--quiet",

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -4,7 +4,6 @@ package lint
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/caarlos0/log"
 	"github.com/elhub/gh-dxp/pkg/config"
@@ -32,7 +31,7 @@ func Run(exe utils.Executor, _ *config.Settings, opts *Options) error {
 		args = append(args, "-e", "MEGALINTER_CONFIG=https://raw.githubusercontent.com/elhub/devxp-lint-configuration/main/resources/.mega-linter.yml")
 	}
 	if !opts.LintAll && opts.Directory == "" {
-		changedFiles, err := getChangedFiles(exe)
+		changedFiles, err := utils.GetChangedFiles(exe)
 		if err != nil {
 			return err
 		}
@@ -59,37 +58,4 @@ func Run(exe utils.Executor, _ *config.Settings, opts *Options) error {
 		return err
 	}
 	return nil
-}
-
-func getChangedFiles(exe utils.Executor) ([]string, error) {
-	branchString, err := exe.Command("git", "branch")
-	if err != nil {
-		return []string{}, err
-	}
-
-	branchList := ConvertTerminalOutputIntoList(branchString)
-
-	var changedFiles []string
-
-	if len(branchList) > 0 {
-		changedFilesString, err := exe.Command("git", "diff", "--name-only", "main", "--relative")
-		changedFiles = ConvertTerminalOutputIntoList(changedFilesString)
-		if err != nil {
-			return []string{}, err
-		}
-	} else {
-		changedFiles, err = utils.GetTrackedChanges(exe)
-		if err != nil {
-			return []string{}, err
-		}
-	}
-	return changedFiles, nil
-}
-
-// ConvertTerminalOutputIntoList converts terminal output on multiple lines to a list of strings
-func ConvertTerminalOutputIntoList(changedFilesString string) []string {
-	if len(changedFilesString) == 0 {
-		return []string{}
-	}
-	return strings.Split(strings.TrimSpace(changedFilesString), "\n")
 }

--- a/pkg/pr/prcreate.go
+++ b/pkg/pr/prcreate.go
@@ -181,7 +181,7 @@ func createPR(
 	// Get the title
 	pr.Title = getDefaultTitle(commits)
 	if !options.TestRun {
-		pr.Title, err = askForString("Title", pr.Title)
+		pr.Title, err = utils.AskForString("Title", pr.Title)
 		if err != nil {
 			return pr, err
 		}
@@ -216,13 +216,13 @@ func createBody(options *CreateOptions, commits string) (string, error) {
 	}
 
 	if !options.TestRun {
-		editBody, err := askToConfirm(bodySurvey)
+		editBody, err := utils.AskToConfirm(bodySurvey)
 		if err != nil {
 			return "", err
 		}
 
 		if editBody {
-			editedBody, errB := askForMultiline("Description:\n")
+			editedBody, errB := utils.AskForMultiline("Description:\n")
 			if errB != nil {
 				return "", errB
 			}
@@ -287,7 +287,7 @@ func issuesChanges(options *CreateOptions) (string, error) {
 	// Optionally add the issue ID(s) to the PR body.
 	body := ""
 	if !options.TestRun {
-		issueIDString, errI := askForString("Issue IDs (seperate with commas):", "")
+		issueIDString, errI := utils.AskForString("Issue IDs (seperate with commas):", "")
 		if errI != nil {
 			return "", errI
 		}
@@ -310,7 +310,7 @@ func issuesChanges(options *CreateOptions) (string, error) {
 
 func testingChanges(options *CreateOptions) (string, error) {
 	if !options.TestRun {
-		newTestConfirm, err := askToConfirm("Did you add new tests?")
+		newTestConfirm, err := utils.AskToConfirm("Did you add new tests?")
 		if err != nil {
 			return "", err
 		}
@@ -332,7 +332,7 @@ func handleUncommittedChanges(exe utils.Executor, options *CreateOptions) ([]str
 	}
 
 	if len(untrackedChanges) > 0 && !options.TestRun {
-		res, err := askToConfirm(formatUntrackedFileChangesQuestion(untrackedChanges))
+		res, err := utils.AskToConfirm(formatUntrackedFileChangesQuestion(untrackedChanges))
 		if err != nil {
 			return []string{}, err
 		}
@@ -348,7 +348,7 @@ func handleUncommittedChanges(exe utils.Executor, options *CreateOptions) ([]str
 	}
 
 	if len(trackedChanges) > 0 && !options.TestRun && options.CommitMessage == "" {
-		res, err := askToConfirm(formatTrackedFileChangesQuestion(trackedChanges))
+		res, err := utils.AskToConfirm(formatTrackedFileChangesQuestion(trackedChanges))
 		if err != nil {
 			return []string{}, err
 		}
@@ -397,41 +397,6 @@ func addDocSection(body string, section string) string {
 	return body
 }
 
-func askToConfirm(question string) (bool, error) {
-	confirm := false
-	err := survey.AskOne(&survey.Confirm{
-		Message: question,
-	}, &confirm, survey.WithValidator(survey.Required))
-	if err != nil {
-		return false, err
-	}
-	return confirm, nil
-}
-
-func askForString(question string, defaultAnswer string) (string, error) {
-	var title string
-	prompt := &survey.Input{
-		Message: question,
-		Default: defaultAnswer,
-	}
-	err := survey.AskOne(prompt, &title)
-	if err != nil {
-		return "", err
-	}
-	return title, nil
-}
-
-func askForMultiline(question string) (string, error) {
-	lines := ""
-	err := survey.AskOne(&survey.Multiline{
-		Message: question,
-	}, &lines, survey.WithValidator(survey.Required))
-	if err != nil {
-		return lines, err
-	}
-	return lines, nil
-}
-
 func getDefaultTitle(commits string) string {
 	lines := strings.Split(commits, "\n")
 	if len(lines) > 0 {
@@ -460,7 +425,7 @@ func addAndCommitFiles(exe utils.Executor, files []string, options *CreateOption
 	} else {
 
 		if !options.TestRun {
-			commitMessage, err = askForString("Please enter a commit message: ", "")
+			commitMessage, err = utils.AskForString("Please enter a commit message: ", "")
 			if err != nil {
 				return err
 			} else if len(commitMessage) == 0 {
@@ -530,7 +495,7 @@ func getNewBranchName(options *CreateOptions) (string, error) {
 	}
 
 	if !options.TestRun {
-		inputBranchName, err := askForString("You are currently on the base branch. Please specify a temporary branch name: ", "")
+		inputBranchName, err := utils.AskForString("You are currently on the base branch. Please specify a temporary branch name: ", "")
 		if err != nil {
 			return "", err
 		}

--- a/pkg/pr/prcreate_test.go
+++ b/pkg/pr/prcreate_test.go
@@ -1,37 +1,17 @@
 package pr_test
 
 import (
-	"bytes"
-	"context"
 	"testing"
 
 	"github.com/elhub/gh-dxp/pkg/config"
-	"github.com/elhub/gh-dxp/pkg/lint"
 	"github.com/elhub/gh-dxp/pkg/pr"
+	"github.com/elhub/gh-dxp/pkg/testutils"
+	"github.com/elhub/gh-dxp/pkg/utils"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
-
-type MockExecutor struct {
-	mock.Mock
-}
-
-func (m *MockExecutor) Command(name string, arg ...string) (string, error) {
-	args := m.Called(name, arg)
-	return args.String(0), args.Error(1)
-}
-
-func (m *MockExecutor) CommandContext(ctx context.Context, name string, arg ...string) error {
-	args := m.Called(ctx, name, arg)
-	return args.Error(1)
-}
-
-func (m *MockExecutor) GH(arg ...string) (bytes.Buffer, error) {
-	args := m.Called(arg)
-	return *bytes.NewBufferString(args.String(0)), args.Error(1)
-}
 
 func TestExecuteCreate(t *testing.T) {
 	tests := []struct {
@@ -240,9 +220,9 @@ func TestExecuteCreate(t *testing.T) {
 				"MEGALINTER_CONFIG=https://raw.githubusercontent.com/elhub/devxp-lint-configuration/main/resources/.mega-linter.yml"}
 
 			linterArgs = append(linterArgs, "--filesonly")
-			linterArgs = append(linterArgs, lint.ConvertTerminalOutputIntoList(tt.modifiedFiles)...)
+			linterArgs = append(linterArgs, utils.ConvertTerminalOutputIntoList(tt.modifiedFiles)...)
 
-			mockExe := new(MockExecutor)
+			mockExe := new(testutils.MockExecutor)
 			mockExe.On("Command", "git", []string{"rev-parse", "--show-toplevel"}).Return("/home/repo-name", nil)
 			mockExe.On("Command", "git", []string{"status", "--porcelain"}).Return(tt.currentChanges, nil)
 			mockExe.On("Command", "git", []string{"branch", "--show-current"}).Return(tt.currentBranch, tt.currentBranchErr)

--- a/pkg/pr/prmerge_test.go
+++ b/pkg/pr/prmerge_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/elhub/gh-dxp/pkg/pr"
+	"github.com/elhub/gh-dxp/pkg/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -61,7 +62,7 @@ func TestExecuteMerge(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mockExe := new(MockExecutor)
+			mockExe := new(testutils.MockExecutor)
 			mockExe.On("Command", "git", []string{"branch", "--show-current"}).Return(tt.pushBranch, tt.pushBranchErr)
 			mockExe.On("GH", []string{"pr", "list", "-H", tt.pushBranch, "--json", "number", "--jq", ".[].number"}).
 				Return(tt.prNumber, tt.prNumberErr)

--- a/pkg/pr/prupdate_test.go
+++ b/pkg/pr/prupdate_test.go
@@ -4,8 +4,9 @@ import (
 	"testing"
 
 	"github.com/elhub/gh-dxp/pkg/config"
-	"github.com/elhub/gh-dxp/pkg/lint"
 	"github.com/elhub/gh-dxp/pkg/pr"
+	"github.com/elhub/gh-dxp/pkg/testutils"
+	"github.com/elhub/gh-dxp/pkg/utils"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -144,9 +145,9 @@ func TestExecuteUpdate(t *testing.T) {
 				"MEGALINTER_CONFIG=https://raw.githubusercontent.com/elhub/devxp-lint-configuration/main/resources/.mega-linter.yml"}
 
 			linterArgs = append(linterArgs, "--filesonly")
-			linterArgs = append(linterArgs, lint.ConvertTerminalOutputIntoList(tt.modifiedFiles)...)
+			linterArgs = append(linterArgs, utils.ConvertTerminalOutputIntoList(tt.modifiedFiles)...)
 
-			mockExe := new(MockExecutor)
+			mockExe := new(testutils.MockExecutor)
 			mockExe.On("Command", "git", []string{"rev-parse", "--show-toplevel"}).Return("/home/repo-name", nil)
 			mockExe.On("Command", "git", []string{"status", "--porcelain"}).Return(tt.currentChanges, nil)
 			mockExe.On("Command", "git", []string{"branch", "--show-current"}).Return(tt.currentBranch, tt.currentBranchErr)

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -1,34 +1,13 @@
 package status_test
 
 import (
-	"bytes"
-	"context"
 	"testing"
 
 	"github.com/elhub/gh-dxp/pkg/status"
+	"github.com/elhub/gh-dxp/pkg/testutils"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
-
-type MockExecutor struct {
-	mock.Mock
-}
-
-func (m *MockExecutor) Command(name string, arg ...string) (string, error) {
-	args := m.Called(name, arg)
-	return args.String(0), args.Error(1)
-}
-
-func (m *MockExecutor) CommandContext(ctx context.Context, name string, arg ...string) error {
-	args := m.Called(ctx, name, arg)
-	return args.Error(1)
-}
-
-func (m *MockExecutor) GH(arg ...string) (bytes.Buffer, error) {
-	args := m.Called(arg)
-	return *bytes.NewBufferString(args.String(0)), args.Error(1)
-}
 
 func TestStatusAll(t *testing.T) {
 	tests := []struct {
@@ -75,7 +54,7 @@ func TestStatusAll(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mockExec := new(MockExecutor)
+			mockExec := new(testutils.MockExecutor)
 			mockExec.On("Command", "git", []string{"remote", "get-url", "origin"}).
 				Return("git@github.com:elhub/demo.git", nil)
 			mockExec.On("GH", []string{"pr", "status"}).Return(tt.expected, nil)

--- a/pkg/test/test_test.go
+++ b/pkg/test/test_test.go
@@ -1,34 +1,14 @@
 package test_test
 
 import (
-	"bytes"
-	"context"
 	"errors"
 	"testing"
 
 	"github.com/elhub/gh-dxp/pkg/test"
+	"github.com/elhub/gh-dxp/pkg/testutils"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
-
-type MockExecutor struct {
-	mock.Mock
-}
-
-func (m *MockExecutor) Command(name string, arg ...string) (string, error) {
-	args := m.Called(name, arg)
-	return args.String(0), args.Error(1)
-}
-
-func (m *MockExecutor) CommandContext(ctx context.Context, name string, arg ...string) error {
-	args := m.Called(ctx, name, arg)
-	return args.Error(1)
-}
-
-func (m *MockExecutor) GH(arg ...string) (bytes.Buffer, error) {
-	args := m.Called(arg)
-	return *bytes.NewBufferString(args.String(0)), args.Error(1)
-}
 
 func TestExecute(t *testing.T) {
 	tests := []struct {
@@ -80,7 +60,7 @@ func TestExecute(t *testing.T) {
 				return path == tt.testFile
 			}
 
-			mockExe := new(MockExecutor)
+			mockExe := new(testutils.MockExecutor)
 
 			mockExe.On("Command", "git", []string{"rev-parse", "--show-toplevel"}).Return(tt.gitRoot, tt.gitRootError)
 			mockExe.On("CommandContext", mock.Anything, "gradlew", []string{"test"}).Return(nil, tt.expectedErr)

--- a/pkg/testutils/mockexecutor.go
+++ b/pkg/testutils/mockexecutor.go
@@ -1,0 +1,45 @@
+package testutils
+
+import (
+	"bytes"
+	"context"
+
+	"github.com/stretchr/testify/mock"
+)
+
+// MockExecutor is a mock implementation of the Executor interface.
+type MockExecutor struct {
+	mock.Mock
+}
+
+// Command pretends to run an OS command and returns its output.
+func (m *MockExecutor) Command(name string, arg ...string) (string, error) {
+	args := m.Called(name, arg)
+	return args.String(0), args.Error(1)
+}
+
+// CommandContext pretends to run an OS command with a context and returns an error.
+func (m *MockExecutor) CommandContext(ctx context.Context, name string, arg ...string) error {
+	args := m.Called(ctx, name, arg)
+	return args.Error(1)
+}
+
+// GH pretends to run a GitHub CLI command and returns its output.
+func (m *MockExecutor) GH(arg ...string) (bytes.Buffer, error) {
+	args := m.Called(arg)
+	return *bytes.NewBufferString(args.String(0)), args.Error(1)
+}
+
+// Chdir pretends to change the current working directory.
+func (m *MockExecutor) Chdir(dir string) error {
+	args := m.Called(dir)
+	return args.Error(1)
+}
+
+// MockContent represents the content of a mock method call to MockExecutor.
+type MockContent struct {
+	Method string
+	Args   interface{}
+	Out    string
+	Err    error
+}

--- a/pkg/utils/directory_test.go
+++ b/pkg/utils/directory_test.go
@@ -1,0 +1,196 @@
+package utils_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/elhub/gh-dxp/pkg/testutils"
+	"github.com/elhub/gh-dxp/pkg/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetGitRootDirectory(t *testing.T) {
+	tests := []struct {
+		name     string
+		mocks    []testutils.MockContent
+		expected string
+		wantErr  bool
+	}{
+		{
+			name: "success",
+			mocks: []testutils.MockContent{
+				{
+					Method: "Command",
+					Args:   []interface{}{"git", []string{"rev-parse", "--show-toplevel"}},
+					Out:    "/path/to/repo\n",
+					Err:    nil,
+				},
+			},
+			expected: "/path/to/repo",
+			wantErr:  false,
+		},
+		{
+			name: "failure",
+			mocks: []testutils.MockContent{
+				{
+					Method: "Command",
+					Args:   []interface{}{"git", []string{"rev-parse", "--show-toplevel"}},
+					Out:    "",
+					Err:    errors.New("not a git repository"),
+				},
+			},
+			expected: "",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockExe := new(testutils.MockExecutor)
+			for _, mock := range tt.mocks {
+				mockExe.On(mock.Method, mock.Args.([]interface{})...).Return(mock.Out, mock.Err)
+			}
+
+			got, err := utils.GetGitRootDirectory(mockExe)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, got)
+			}
+
+			mockExe.AssertExpectations(t)
+		})
+	}
+}
+
+func TestSetWorkDirToGitHubRoot(t *testing.T) {
+	tests := []struct {
+		name    string
+		mocks   []testutils.MockContent
+		wantErr bool
+	}{
+		{
+			name: "success",
+			mocks: []testutils.MockContent{
+				{
+					Method: "Command",
+					Args:   []interface{}{"git", []string{"remote", "get-url", "origin"}},
+					Out:    "git@github.com:example/test.git",
+					Err:    nil,
+				},
+				{
+					Method: "Command",
+					Args:   []interface{}{"git", []string{"rev-parse", "--show-toplevel"}},
+					Out:    "/path/to/repo\n",
+					Err:    nil,
+				},
+				{
+					Method: "Chdir",
+					Args:   []interface{}{"/path/to/repo"},
+					Out:    "",
+					Err:    nil,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "failure: git remote returns error",
+			mocks: []testutils.MockContent{
+				{
+					Method: "Command",
+					Args:   []interface{}{"git", []string{"remote", "get-url", "origin"}},
+					Out:    "",
+					Err:    errors.New("not a git repository"),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "failure: git remote returns invalid url",
+			mocks: []testutils.MockContent{
+				{
+					Method: "Command",
+					Args:   []interface{}{"git", []string{"remote", "get-url", "origin"}},
+					Out:    "thiswasnotagithuburl",
+					Err:    nil,
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockExe := new(testutils.MockExecutor)
+			for _, mock := range tt.mocks {
+				mockExe.On(mock.Method, mock.Args.([]interface{})...).Return(mock.Out, mock.Err)
+			}
+
+			err := utils.SetWorkDirToGitHubRoot(mockExe)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			mockExe.AssertExpectations(t)
+		})
+	}
+}
+
+func TestListFilesInDirectory(t *testing.T) {
+	tests := []struct {
+		name     string
+		mocks    []testutils.MockContent
+		expected []string
+		wantErr  bool
+	}{
+		{
+			name: "success",
+			mocks: []testutils.MockContent{
+				{
+					Method: "Command",
+					Args:   []interface{}{"ls", []string{"/path/to/dir"}},
+					Out:    "file1\nfile2\n",
+					Err:    nil,
+				},
+			},
+			expected: []string{"file1", "file2"},
+			wantErr:  false,
+		},
+		{
+			name: "failure",
+			mocks: []testutils.MockContent{
+				{
+					Method: "Command",
+					Args:   []interface{}{"ls", []string{"/path/to/dir"}},
+					Out:    "",
+					Err:    errors.New("directory does not exist"),
+				},
+			},
+			expected: nil,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockExe := new(testutils.MockExecutor)
+			for _, mock := range tt.mocks {
+				mockExe.On(mock.Method, mock.Args.([]interface{})...).Return(mock.Out, mock.Err)
+			}
+
+			got, err := utils.ListFilesInDirectory(mockExe, "/path/to/dir")
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, got)
+			}
+
+			mockExe.AssertExpectations(t)
+		})
+	}
+}

--- a/pkg/utils/executor.go
+++ b/pkg/utils/executor.go
@@ -4,13 +4,6 @@ package utils
 import (
 	"bytes"
 	"context"
-	"fmt"
-	"os"
-	"os/exec"
-	"strings"
-
-	"github.com/caarlos0/log"
-	"github.com/cli/go-gh/v2"
 )
 
 // Executor is an interface for running commands.
@@ -18,50 +11,5 @@ type Executor interface {
 	Command(name string, args ...string) (string, error)
 	CommandContext(ctx context.Context, name string, arg ...string) error
 	GH(args ...string) (bytes.Buffer, error)
-}
-
-// LinuxExecutorImpl is the type of the Executor interface for Linux systems.
-type LinuxExecutorImpl struct {
-	ExecCommand func(name string, args ...string) *exec.Cmd
-}
-
-// LinuxExecutor returns a new LinuxExecutorImpl.
-func LinuxExecutor() *LinuxExecutorImpl {
-	return &LinuxExecutorImpl{
-		ExecCommand: exec.Command,
-	}
-}
-
-// Command runs an OS command and returns its output.
-func (e *LinuxExecutorImpl) Command(name string, args ...string) (string, error) {
-	log.Debug(fmt.Sprintf("Running '%s %s'", name, strings.Join(args, " ")))
-	cmd := e.ExecCommand(name, args...)
-	bytes, err := cmd.CombinedOutput()
-	if err != nil {
-		log.Error(string(bytes))
-	}
-	return string(bytes), err
-}
-
-// CommandContext runs an OS command with a context and returns an error.
-// The output is printed to stdout and stderr.
-func (e *LinuxExecutorImpl) CommandContext(ctx context.Context, name string, args ...string) error {
-	log.Debug(fmt.Sprintf("Running with context '%s %s'", name, strings.Join(args, " ")))
-	cmd := exec.CommandContext(ctx, name, args...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	err := cmd.Run()
-	return err
-}
-
-// GH runs a GitHub CLI command and returns its output.
-func (e *LinuxExecutorImpl) GH(args ...string) (bytes.Buffer, error) {
-	log.Debug(fmt.Sprintf("Running gh '%s'", strings.Join(args, " ")))
-	stdOut, stdErr, err := gh.Exec(args...)
-	if err != nil {
-		log.Error(stdErr.String())
-		log.Debug(fmt.Sprintf("Error running GH command: %s", err.Error()))
-		return stdErr, err
-	}
-	return stdOut, err
+	Chdir(dir string) error
 }

--- a/pkg/utils/files.go
+++ b/pkg/utils/files.go
@@ -1,9 +1,85 @@
 package utils
 
-import "os"
+import (
+	"os"
+	"regexp"
+	"strings"
+)
 
 // FileExists returns true if a given file exists, and false if it doesn't.
 func FileExists(path string) bool {
 	_, err := os.Stat(path)
 	return !os.IsNotExist(err)
+}
+
+// GetChangedFiles returns a list of changed files in the current repo
+func GetChangedFiles(exe Executor) ([]string, error) {
+	branchString, err := exe.Command("git", "branch")
+	if err != nil {
+		return []string{}, err
+	}
+
+	branchList := ConvertTerminalOutputIntoList(branchString)
+
+	var changedFiles []string
+
+	if len(branchList) > 0 {
+		changedFilesString, err := exe.Command("git", "diff", "--name-only", "main", "--relative")
+		changedFiles = ConvertTerminalOutputIntoList(changedFilesString)
+		if err != nil {
+			return []string{}, err
+		}
+	} else {
+		changedFiles, err = GetTrackedChanges(exe)
+		if err != nil {
+			return []string{}, err
+		}
+	}
+	return changedFiles, nil
+}
+
+// GetUntrackedChanges returns a list of file names for unchanged files in the current repo
+func GetUntrackedChanges(exe Executor) ([]string, error) {
+	re := regexp.MustCompile(`^\?\?`)
+
+	return getChanges(exe, re)
+}
+
+// GetTrackedChanges returns a list of file names for changed files in the current repo
+func GetTrackedChanges(exe Executor) ([]string, error) {
+	re := regexp.MustCompile(`^([ADMRT]|\s)([ADMRT]|\s)\s`) // This regex is intended to catch all tracked changes except for unmerged conflicts
+	return getChanges(exe, re)
+}
+
+// Checks the current repo state for any changes matching a given regex 're'
+func getChanges(exe Executor, re *regexp.Regexp) ([]string, error) {
+	changeString, err := exe.Command("git", "status", "--porcelain")
+	if err != nil {
+		return []string{}, err
+	}
+
+	changes := strings.Split(changeString, "\n")
+	matchedChanges := filter(changes, re.MatchString)
+
+	// Remove the regex matched part of the string, leaving only the file name
+	for i, s := range matchedChanges {
+		matchedChanges[i] = re.ReplaceAllString(s, "")
+	}
+
+	// Split string on '->' and capture the last element, in order to catch changes of type 'oldfilename.txt -> newfilename.txt'
+	for i, s := range matchedChanges {
+		macgyver := strings.Split(s, "->")
+		matchedChanges[i] = strings.TrimSpace(macgyver[len(macgyver)-1])
+	}
+	return matchedChanges, nil
+}
+
+func filter(list []string, test func(string) bool) []string {
+	ret := []string{}
+	for _, s := range list {
+		if test(s) {
+			ret = append(ret, s)
+		}
+	}
+	return ret
 }

--- a/pkg/utils/linuxexecutor.go
+++ b/pkg/utils/linuxexecutor.go
@@ -1,0 +1,65 @@
+// Package utils provides common utilities for the gh-dxp extension.
+package utils
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/caarlos0/log"
+	"github.com/cli/go-gh/v2"
+)
+
+// LinuxExecutorImpl is the type of the Executor interface for Linux systems.
+type LinuxExecutorImpl struct {
+	ExecCommand func(name string, args ...string) *exec.Cmd
+}
+
+// LinuxExecutor returns a new LinuxExecutorImpl.
+func LinuxExecutor() *LinuxExecutorImpl {
+	return &LinuxExecutorImpl{
+		ExecCommand: exec.Command,
+	}
+}
+
+// Command runs an OS command and returns its output.
+func (e *LinuxExecutorImpl) Command(name string, args ...string) (string, error) {
+	log.Debug(fmt.Sprintf("Running '%s %s'", name, strings.Join(args, " ")))
+	cmd := e.ExecCommand(name, args...)
+	bytes, err := cmd.CombinedOutput()
+	if err != nil {
+		log.Error(string(bytes))
+	}
+	return string(bytes), err
+}
+
+// CommandContext runs an OS command with a context and returns an error.
+// The output is printed to stdout and stderr.
+func (e *LinuxExecutorImpl) CommandContext(ctx context.Context, name string, args ...string) error {
+	log.Debug(fmt.Sprintf("Running with context '%s %s'", name, strings.Join(args, " ")))
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return err
+}
+
+// GH runs a GitHub CLI command and returns its output.
+func (e *LinuxExecutorImpl) GH(args ...string) (bytes.Buffer, error) {
+	log.Debug(fmt.Sprintf("Running gh '%s'", strings.Join(args, " ")))
+	stdOut, stdErr, err := gh.Exec(args...)
+	if err != nil {
+		log.Error(stdErr.String())
+		log.Debug(fmt.Sprintf("Error running GH command: %s", err.Error()))
+		return stdErr, err
+	}
+	return stdOut, err
+}
+
+// Chdir changes the current working directory.
+func (e *LinuxExecutorImpl) Chdir(dir string) error {
+	return os.Chdir(dir)
+}

--- a/pkg/utils/terminal.go
+++ b/pkg/utils/terminal.go
@@ -1,0 +1,53 @@
+package utils
+
+import (
+	"strings"
+
+	"github.com/AlecAivazis/survey/v2"
+)
+
+// ConvertTerminalOutputIntoList converts terminal output on multiple lines to a list of strings
+func ConvertTerminalOutputIntoList(changedFilesString string) []string {
+	if len(changedFilesString) == 0 {
+		return []string{}
+	}
+	return strings.Split(strings.TrimSpace(changedFilesString), "\n")
+}
+
+// AskToConfirm prompts the user with a yes/no question and returns their response.
+func AskToConfirm(question string) (bool, error) {
+	confirm := false
+	err := survey.AskOne(&survey.Confirm{
+		Message: question,
+	}, &confirm, survey.WithValidator(survey.Required))
+	if err != nil {
+		return false, err
+	}
+	return confirm, nil
+}
+
+// AskForString prompts the user for a string input and returns the response.
+func AskForString(question string, defaultAnswer string) (string, error) {
+	var title string
+	prompt := &survey.Input{
+		Message: question,
+		Default: defaultAnswer,
+	}
+	err := survey.AskOne(prompt, &title)
+	if err != nil {
+		return "", err
+	}
+	return title, nil
+}
+
+// AskForMultiline prompts the user for a multiline input and returns the response.
+func AskForMultiline(question string) (string, error) {
+	lines := ""
+	err := survey.AskOne(&survey.Multiline{
+		Message: question,
+	}, &lines, survey.WithValidator(survey.Required))
+	if err != nil {
+		return lines, err
+	}
+	return lines, nil
+}


### PR DESCRIPTION
## 📝 Description

* Add terminal-helper commands to utils
* Added file manipulation function to utils
* Added os.Chdir to the executor, so that it can be mocked
* Made MockExecutor a struct in its own package (testutils). This ensures that we don't need to copy-paste the same MockExecutor to every package. Could use build tags to ensure this does not get built with the regular code, but that breaks VsCode.
* Added specific tests for the utils code. More testing is still needed, though.
* Refactor initiated to support future changes to PR-create/update (where we need the files.go functionality)

## 🔗 Issue ID(s): TDX-625

## 📋 Checklist

* ✅ Lint checks passed on local machine.
* ✅ Unit tests passed on local machine.
* ✅ This PR adds news tests.
