### PR TITLE
Add automated documentation checks to PR info

### DIFF
--- a/pkg/pr/prcreate.go
+++ b/pkg/pr/prcreate.go
@@ -363,8 +363,8 @@ func documentationChanges(exe utils.Executor) (string, error) {
 		return "", err
 	}
 
-	readmewasUpdated := utils.CheckFilesUpdated(changedFiles, []string{"README.md"})
-	docsWereUpdated := utils.CheckFilesUpdated(changedFiles, []string{"docs"})
+	readmewasUpdated := utils.CheckFilesUpdated(changedFiles, []string{"README.md$"})
+	docsWereUpdated := utils.CheckFilesUpdated(changedFiles, []string{"/docs/"})
 
 	selectedDocs := []string{}
 	if readmewasUpdated {

--- a/pkg/testutils/mockexecutor.go
+++ b/pkg/testutils/mockexecutor.go
@@ -43,3 +43,12 @@ type MockContent struct {
 	Out    string
 	Err    error
 }
+
+// NewMockExecutor creates a new MockExecutor with the given mocks.
+func NewMockExecutor(mocks []MockContent) *MockExecutor {
+	mockExe := new(MockExecutor)
+	for _, mock := range mocks {
+		mockExe.On(mock.Method, mock.Args.([]interface{})...).Return(mock.Out, mock.Err)
+	}
+	return mockExe
+}

--- a/pkg/testutils/mockexecutor_test.go
+++ b/pkg/testutils/mockexecutor_test.go
@@ -1,0 +1,59 @@
+package testutils_test
+
+import (
+	"testing"
+
+	"github.com/elhub/gh-dxp/pkg/testutils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewMockExecutor(t *testing.T) {
+	mocks := []testutils.MockContent{
+		{
+			Method: "Command",
+			Args:   []interface{}{"git", []string{"rev-parse", "--show-toplevel"}},
+			Out:    "/path/to/repo\n",
+			Err:    nil,
+		},
+		{
+			Method: "CommandContext",
+			Args:   []interface{}{nil, "git", []string{"rev-parse", "--show-toplevel"}},
+			Out:    "",
+			Err:    nil,
+		},
+		{
+			Method: "GH",
+			Args:   []interface{}{[]string{"repo", "view"}},
+			Out:    "mocked output",
+			Err:    nil,
+		},
+		{
+			Method: "Chdir",
+			Args:   []interface{}{"/mock/path"},
+			Out:    "",
+			Err:    nil,
+		},
+	}
+
+	mockExe := testutils.NewMockExecutor(mocks)
+
+	// Test Command method
+	cOutput, err := mockExe.Command("git", "rev-parse", "--show-toplevel")
+	assert.Equal(t, "/path/to/repo\n", cOutput)
+	assert.NoError(t, err)
+
+	// Test CommandContext method
+	err = mockExe.CommandContext(nil, "git", "rev-parse", "--show-toplevel")
+	assert.NoError(t, err)
+
+	// Test GH method
+	ghOutput, err := mockExe.GH("repo", "view")
+	assert.NoError(t, err)
+	assert.Equal(t, "mocked output", ghOutput.String())
+
+	// Test Chdir method
+	err = mockExe.Chdir("/mock/path")
+	assert.NoError(t, err)
+
+	mockExe.AssertExpectations(t)
+}

--- a/pkg/utils/directory_test.go
+++ b/pkg/utils/directory_test.go
@@ -47,10 +47,12 @@ func TestGetGitRootDirectory(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mockExe := new(testutils.MockExecutor)
-			for _, mock := range tt.mocks {
-				mockExe.On(mock.Method, mock.Args.([]interface{})...).Return(mock.Out, mock.Err)
-			}
+			//
+			mockExe := testutils.NewMockExecutor(tt.mocks)
+			//new(testutils.MockExecutor)
+			//for _, mock := range tt.mocks {
+			//		mockExe.On(mock.Method, mock.Args.([]interface{})...).Return(mock.Out, mock.Err)
+			//	}
 
 			got, err := utils.GetGitRootDirectory(mockExe)
 			if tt.wantErr {

--- a/pkg/utils/files.go
+++ b/pkg/utils/files.go
@@ -38,6 +38,22 @@ func GetChangedFiles(exe Executor) ([]string, error) {
 	return changedFiles, nil
 }
 
+// CheckFilesUpdated checks if any of the specified patterns match the changed files.
+func CheckFilesUpdated(changedFiles []string, patterns []string) bool {
+	for _, file := range changedFiles {
+		for _, pattern := range patterns {
+			matched, err := regexp.MatchString(pattern, file)
+			if err != nil {
+				continue
+			}
+			if matched {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // GetUntrackedChanges returns a list of file names for unchanged files in the current repo
 func GetUntrackedChanges(exe Executor) ([]string, error) {
 	re := regexp.MustCompile(`^\?\?`)

--- a/pkg/utils/files_test.go
+++ b/pkg/utils/files_test.go
@@ -1,0 +1,160 @@
+package utils_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/elhub/gh-dxp/pkg/testutils"
+	"github.com/elhub/gh-dxp/pkg/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetChangedFiles(t *testing.T) {
+	tests := []struct {
+		name        string
+		mocks       []testutils.MockContent
+		expected    []string
+		expectedErr error
+	}{
+		{
+			name: "success",
+			mocks: []testutils.MockContent{
+				{
+					Method: "Command",
+					Args:   []interface{}{"git", []string{"branch"}},
+					Out:    "main\n",
+					Err:    nil,
+				},
+				{
+					Method: "Command",
+					Args:   []interface{}{"git", []string{"diff", "--name-only", "main", "--relative"}},
+					Out:    "README.md\n",
+					Err:    nil,
+				},
+			},
+			expected:    []string{"README.md"},
+			expectedErr: nil,
+		},
+		{
+			name: "failure (not in git repository)",
+			mocks: []testutils.MockContent{
+				{
+					Method: "Command",
+					Args:   []interface{}{"git", []string{"branch"}},
+					Out:    "",
+					Err:    errors.New("not a git repository"),
+				},
+			},
+			expected:    []string{},
+			expectedErr: errors.New("not a git repository"),
+		},
+		{
+			name: "failure (error in git diff command)",
+			mocks: []testutils.MockContent{
+				{
+					Method: "Command",
+					Args:   []interface{}{"git", []string{"branch"}},
+					Out:    "main\n",
+					Err:    nil,
+				},
+				{
+					Method: "Command",
+					Args:   []interface{}{"git", []string{"diff", "--name-only", "main", "--relative"}},
+					Out:    "",
+					Err:    errors.New("error in git diff command"),
+				},
+			},
+			expected:    []string{},
+			expectedErr: errors.New("error in git diff command"),
+		},
+		{
+			name: "failure (error in git branch command)",
+			mocks: []testutils.MockContent{
+				{
+					Method: "Command",
+					Args:   []interface{}{"git", []string{"branch"}},
+					Out:    "",
+					Err:    errors.New("error in git branch command"),
+				},
+			},
+			expected:    []string{},
+			expectedErr: errors.New("error in git branch command"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockExe := testutils.NewMockExecutor(tt.mocks)
+			changedFiles, err := utils.GetChangedFiles(mockExe)
+			assert.Equal(t, tt.expected, changedFiles)
+			assert.Equal(t, tt.expectedErr, err)
+			mockExe.AssertExpectations(t)
+		})
+	}
+
+}
+
+func TestCheckFilesUpdated(t *testing.T) {
+	tests := []struct {
+		name          string
+		changedFiles  []string
+		patterns      []string
+		expectedMatch bool
+	}{
+		{
+			name:          "No files changed",
+			changedFiles:  []string{},
+			patterns:      []string{"README.md$"},
+			expectedMatch: false,
+		},
+		{
+			name:          "Match specific file name",
+			changedFiles:  []string{"README.md"},
+			patterns:      []string{"README.md$"},
+			expectedMatch: true,
+		},
+		{
+			name:          "Match end of path",
+			changedFiles:  []string{"/path/to/the/README.md"},
+			patterns:      []string{"README.md$"},
+			expectedMatch: true,
+		},
+		{
+			name:          "Do not match part of the path",
+			changedFiles:  []string{"/path/README.md/around/hello.md"},
+			patterns:      []string{"README.md$"},
+			expectedMatch: false,
+		},
+		{
+			name:          "Files in docs directory changed",
+			changedFiles:  []string{"/test/docs/index.md", "/test/docs/guide.md"},
+			patterns:      []string{"/docs/"},
+			expectedMatch: true,
+		},
+		{
+			name:          "Files in docs-like directory changed",
+			changedFiles:  []string{"docsy/index.md", "/src/com/manydocs/helloworld.go"},
+			patterns:      []string{"/docs/"},
+			expectedMatch: false,
+		},
+		{
+			name:          "Multiple patterns matched",
+			changedFiles:  []string{"README.md", "/docs/index.md"},
+			patterns:      []string{"README.md", "/docs/"},
+			expectedMatch: true,
+		},
+		{
+			name:          "No patterns matched",
+			changedFiles:  []string{"main.go", "utils/helper.go"},
+			patterns:      []string{"README.md", "/docs/"},
+			expectedMatch: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			match := utils.CheckFilesUpdated(tt.changedFiles, tt.patterns)
+			assert.Equal(t, tt.expectedMatch, match)
+		})
+	}
+}


### PR DESCRIPTION
## 📝 Description

This change adds automated checks for changes in README and /docs to the PR template.

Created testutils.NewMockExecutor to simplify testing of the documentation, and added tests for that as well.

## 🔗 Issue ID(s): TDX-625

## 📋 Checklist

* ✅ Lint checks passed on local machine.
* ✅ Unit tests passed on local machine.
* ✅ This PR adds news tests.
