### PR TITLE
enable relevant flags in update by setting them as persistentflags in the root pr command [patch]

### DIFF
--- a/pkg/pr/model.go
+++ b/pkg/pr/model.go
@@ -1,5 +1,14 @@
 package pr
 
+// Options represents the options for the pr command.
+type Options struct {
+	TestRun bool
+	NoLint  bool
+	NoUnit  bool
+
+	CommitMessage string
+}
+
 // CreateOptions represents the options for the pr create command.
 type CreateOptions struct {
 	TestRun bool
@@ -26,6 +35,8 @@ type UpdateOptions struct {
 	TestRun bool
 	NoLint  bool
 	NoUnit  bool
+
+	CommitMessage string
 }
 
 // PullRequest represents a pull request.

--- a/pkg/pr/pr.go
+++ b/pkg/pr/pr.go
@@ -2,9 +2,13 @@
 package pr
 
 import (
+	"path/filepath"
 	"strings"
 
 	"github.com/caarlos0/log"
+	"github.com/elhub/gh-dxp/pkg/config"
+	"github.com/elhub/gh-dxp/pkg/lint"
+	"github.com/elhub/gh-dxp/pkg/test"
 	"github.com/elhub/gh-dxp/pkg/utils"
 	"github.com/pkg/errors"
 )
@@ -34,4 +38,120 @@ func GetPRTitle(exe utils.Executor) (string, error) {
 	title := strings.Trim(stdOut.String(), "\n")
 
 	return title, nil
+}
+
+func handleUncommittedChanges(exe utils.Executor, options *Options) ([]string, error) {
+	// Handle presence of untracked changes - ignore or abort
+	untrackedChanges, err := utils.GetUntrackedChanges(exe)
+	if err != nil {
+		return []string{}, err
+	}
+
+	if len(untrackedChanges) > 0 && !options.TestRun {
+		res, err := utils.AskToConfirm(formatUntrackedFileChangesQuestion(untrackedChanges))
+		if err != nil {
+			return []string{}, err
+		}
+		if !res {
+			return []string{}, errors.New("User aborted workflow")
+		}
+	}
+
+	// Handle presence of tracked changes - commit or abort
+	trackedChanges, err := utils.GetTrackedChanges(exe)
+	if err != nil {
+		return []string{}, err
+	}
+
+	if len(trackedChanges) > 0 && !options.TestRun && options.CommitMessage == "" {
+		res, err := utils.AskToConfirm(formatTrackedFileChangesQuestion(trackedChanges))
+		if err != nil {
+			return []string{}, err
+		}
+
+		if !res {
+			return []string{}, errors.New("User aborted workflow")
+		}
+	}
+	return trackedChanges, nil
+}
+
+func addAndCommitFiles(exe utils.Executor, files []string, options *Options) error {
+	var commitMessage string
+	var err error
+
+	if options.CommitMessage != "" {
+		commitMessage = options.CommitMessage
+	} else {
+
+		if !options.TestRun {
+			commitMessage, err = utils.AskForString("Please enter a commit message: ", "")
+			if err != nil {
+				return err
+			} else if len(commitMessage) == 0 {
+				return errors.New("Empty commit message not allowed")
+			}
+		} else {
+			commitMessage = "default commit message"
+		}
+	}
+	// Get git root directory and add to files to get fully qualified paths
+	root, err := utils.GetGitRootDirectory(exe)
+	if err != nil {
+		return err
+	}
+
+	var fullPaths []string
+	for _, filePath := range files {
+		fullPaths = append(fullPaths, filepath.Join(root, filePath))
+	}
+
+	addCommandArgs := append([]string{"add"}, fullPaths...)
+
+	_, err = exe.Command("git", addCommandArgs...)
+	if err != nil {
+		return err
+	}
+
+	// Commit files
+	_, err = exe.Command("git", "commit", "-m", commitMessage)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func performPreCommitOperations(exe utils.Executor, settings *config.Settings, pr PullRequest, options *Options) (PullRequest, error) {
+	// Handle uncommitted changes
+	filesToCommit, err := handleUncommittedChanges(exe, options)
+	if err != nil {
+		return pr, err
+	}
+
+	// Run lint
+	if !options.NoLint {
+		err = lint.Run(exe, settings, &lint.Options{})
+		if err != nil {
+			return pr, err
+		}
+		pr.isLinted = true
+	}
+
+	// Run tests
+	if !options.NoUnit {
+		pr.isTested, err = test.RunTest(exe)
+		if err != nil {
+			return pr, err
+		}
+	}
+
+	if len(filesToCommit) > 0 {
+		err = addAndCommitFiles(exe, filesToCommit, options)
+		if err != nil {
+			return pr, err
+		}
+	}
+
+	return pr, nil
 }

--- a/pkg/pr/prcreate.go
+++ b/pkg/pr/prcreate.go
@@ -57,9 +57,10 @@ func ExecuteCreate(exe utils.Executor, settings *config.Settings, options *Creat
 	}
 
 	prOpts := &Options{
-		TestRun: options.TestRun,
-		NoLint:  options.NoLint,
-		NoUnit:  options.NoUnit,
+		TestRun:       options.TestRun,
+		NoLint:        options.NoLint,
+		NoUnit:        options.NoUnit,
+		CommitMessage: options.CommitMessage,
 	}
 
 	pr, err = performPreCommitOperations(exe, settings, pr, prOpts)
@@ -375,6 +376,7 @@ func setBaseBranch(exe utils.Executor, options *CreateOptions) (string, error) {
 		baseBranch = strings.Trim(stdOut.String(), "\n")
 		options.baseBranch = baseBranch
 	}
+	log.Info("info")
 	return baseBranch, nil
 }
 

--- a/pkg/pr/prcreate.go
+++ b/pkg/pr/prcreate.go
@@ -376,7 +376,6 @@ func setBaseBranch(exe utils.Executor, options *CreateOptions) (string, error) {
 		baseBranch = strings.Trim(stdOut.String(), "\n")
 		options.baseBranch = baseBranch
 	}
-	log.Info("info")
 	return baseBranch, nil
 }
 

--- a/pkg/pr/prupdate.go
+++ b/pkg/pr/prupdate.go
@@ -19,7 +19,7 @@ func ExecuteUpdate(exe utils.Executor, settings *config.Settings, options *Updat
 	}
 	pr.branchID = strings.Trim(currentBranch, "\n")
 
-	opts := &CreateOptions{
+	prOpts := &Options{
 		TestRun: options.TestRun,
 		NoLint:  options.NoLint,
 		NoUnit:  options.NoUnit,
@@ -31,7 +31,7 @@ func ExecuteUpdate(exe utils.Executor, settings *config.Settings, options *Updat
 		return errCheck
 	}
 
-	pr, err := performPreCommitOperations(exe, settings, pr, opts)
+	pr, err := performPreCommitOperations(exe, settings, pr, prOpts)
 	if err != nil {
 		return err
 	}

--- a/pkg/pr/prupdate.go
+++ b/pkg/pr/prupdate.go
@@ -20,9 +20,10 @@ func ExecuteUpdate(exe utils.Executor, settings *config.Settings, options *Updat
 	pr.branchID = strings.Trim(currentBranch, "\n")
 
 	prOpts := &Options{
-		TestRun: options.TestRun,
-		NoLint:  options.NoLint,
-		NoUnit:  options.NoUnit,
+		TestRun:       options.TestRun,
+		NoLint:        options.NoLint,
+		NoUnit:        options.NoUnit,
+		CommitMessage: options.CommitMessage,
 	}
 
 	// Check if PR exists on branch

--- a/pkg/pr/prupdate_test.go
+++ b/pkg/pr/prupdate_test.go
@@ -136,6 +136,14 @@ func TestExecuteUpdate(t *testing.T) {
 			modifiedFiles:    "pkg/cmd/lint.go\npkg/lint/lint.go\n",
 			existingBranches: "main\ndifferentBranch\n",
 			currentBranch:    "branch1",
+			prListNumber:     "1",
+		},
+		{
+			name:             "Test lint is failing",
+			expectedErr:      errors.New("No PR found for branch branch1"),
+			modifiedFiles:    "pkg/cmd/lint.go\npkg/lint/lint.go\n",
+			existingBranches: "main\ndifferentBranch\n",
+			currentBranch:    "branch1",
 		},
 	}
 


### PR DESCRIPTION
## 📝 Description
This PR (unfortunately) does a couple of things
* Refactor/move some common code between pr create and pr update
* Perform existing PR check earlier in the pr update flow
* Add persistentflags to pr command and let subcommands inherit.

## 📋 Checklist

* ✅ Lint checks passed on local machine.
* ✅ Unit tests passed on local machine.
