### PR TITLE
Add upgrade command [minor]

### DIFF
--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -56,6 +56,7 @@ func GenerateCmd(settings *config.Settings, version string) *cobra.Command {
 		TestCmd(exe),
 		TemplateCmd(exe, settings),
 		StatusCmd(exe),
+		UpgradeCmd(exe),
 	)
 
 	return retCmd

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -12,16 +12,19 @@ import (
 
 // Execute runs the main command of the CLI tool.
 func Execute(settings *config.Settings, version string) error {
-	mainCmd := GenerateCmd(settings, version)
+	mainCmd, err := GenerateCmd(settings, version)
+	if err != nil {
+		return err
+	}
 	ctx := context.Background()
 
-	err := mainCmd.ExecuteContext(ctx)
+	err = mainCmd.ExecuteContext(ctx)
 
 	return err
 }
 
 // GenerateCmd sets up the command structure for the CLI tool using Cobra.
-func GenerateCmd(settings *config.Settings, version string) *cobra.Command {
+func GenerateCmd(settings *config.Settings, version string) (*cobra.Command, error) {
 	var (
 		debug bool
 	)
@@ -46,6 +49,13 @@ func GenerateCmd(settings *config.Settings, version string) *cobra.Command {
 	retCmd.PersistentFlags().BoolVar(&debug, "debug", false, "verbose logging")
 
 	exe := utils.LinuxExecutor()
+	isLatestVersion, err := utils.IsLatestVersionOrSnapshot(exe, version)
+	if err != nil {
+		return nil, err
+	}
+	if !isLatestVersion {
+		log.Warn("You may be using an outdated version of gh dxp. Consider running 'gh dxp upgrade' to upgrade to the latest version.")
+	}
 
 	retCmd.AddCommand(
 		AliasCmd(exe),
@@ -59,5 +69,5 @@ func GenerateCmd(settings *config.Settings, version string) *cobra.Command {
 		UpgradeCmd(exe),
 	)
 
-	return retCmd
+	return retCmd, nil
 }

--- a/pkg/cmd/upgrade.go
+++ b/pkg/cmd/upgrade.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"github.com/MakeNowJust/heredoc"
+	"github.com/elhub/gh-dxp/pkg/upgrade"
+	"github.com/elhub/gh-dxp/pkg/utils"
+	"github.com/spf13/cobra"
+)
+
+// UpgradeCmd upgrades the dxp plugin to the latest version
+func UpgradeCmd(exe utils.Executor) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "upgrade",
+		Short: "Upgrade gh dxp",
+		Args:  cobra.ExactArgs(0),
+		Long: heredoc.Docf(`
+			Upgrade gh dxp to latest version`, "`"),
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return upgrade.RunUpgrade(exe)
+		},
+	}
+	return cmd
+}

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -1,0 +1,11 @@
+package upgrade
+
+import "github.com/elhub/gh-dxp/pkg/utils"
+
+// RunUpgrade upgrades gh dxp to the latest version
+func RunUpgrade(exe utils.Executor) error {
+
+	_, err := exe.GH("extension", "upgrade", "elhub/gh-dxp", "--force")
+	return err
+
+}

--- a/pkg/upgrade/upgrade_test.go
+++ b/pkg/upgrade/upgrade_test.go
@@ -1,0 +1,29 @@
+package upgrade_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/elhub/gh-dxp/pkg/testutils"
+	"github.com/elhub/gh-dxp/pkg/upgrade"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunUpgrade(t *testing.T) {
+	ghArgs := []string{"extension", "upgrade", "elhub/gh-dxp", "--force"}
+
+	t.Run("Upgrade successful", func(t *testing.T) {
+		mockExe := new(testutils.MockExecutor)
+		mockExe.On("GH", ghArgs).Return("", nil)
+
+		err := upgrade.RunUpgrade(mockExe)
+		require.NoError(t, err)
+	})
+	t.Run("Upgrade unsuccessful", func(t *testing.T) {
+		mockExe := new(testutils.MockExecutor)
+		mockExe.On("GH", ghArgs).Return("", errors.New("something went wrong"))
+
+		err := upgrade.RunUpgrade(mockExe)
+		require.Error(t, err)
+	})
+}

--- a/pkg/utils/version.go
+++ b/pkg/utils/version.go
@@ -1,0 +1,50 @@
+package utils
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+// GetLatestReleaseVersion fetches the tag of the latest release.
+func GetLatestReleaseVersion(exe Executor) (string, error) {
+
+	ret, err := exe.GH("api", "-H", "Accept: application/vnd.github+json", "-H", "X-GitHub-Api-Version: 2022-11-28", "/repos/elhub/gh-dxp/releases/latest")
+	if err != nil {
+		return "", err
+	}
+
+	var decoded gitHubRelease
+
+	err = json.NewDecoder(&ret).Decode(&decoded)
+	if err != nil {
+		return "", err
+	}
+
+	if decoded.TagName == "" {
+		return "", errors.New("response object contained no tag_name field")
+	}
+
+	return decoded.TagName, nil
+}
+
+// IsLatestVersion checks whether the provided version is the same as the latest release in GitHub.
+func IsLatestVersion(exe Executor, localVersion string) (bool, error) {
+
+	latestVersion, err := GetLatestReleaseVersion(exe)
+	if err != nil {
+		return false, err
+	}
+	return latestVersion == localVersion, nil
+}
+
+// IsLatestVersionOrSnapshot checks whether the provided versin is the same as the latest release in GitHub, OR "SNAPSHOT".
+func IsLatestVersionOrSnapshot(exe Executor, version string) (bool, error) {
+	if version == "SNAPSHOT" {
+		return true, nil
+	}
+	return IsLatestVersion(exe, version)
+}
+
+type gitHubRelease struct {
+	TagName string `json:"tag_name"`
+}

--- a/pkg/utils/version.go
+++ b/pkg/utils/version.go
@@ -8,23 +8,23 @@ import (
 // GetLatestReleaseVersion fetches the tag of the latest release.
 func GetLatestReleaseVersion(exe Executor) (string, error) {
 
-	ret, err := exe.GH("api", "-H", "Accept: application/vnd.github+json", "-H", "X-GitHub-Api-Version: 2022-11-28", "/repos/elhub/gh-dxp/releases/latest")
+	response, err := exe.GH("api", "-H", "Accept: application/vnd.github+json", "-H", "X-GitHub-Api-Version: 2022-11-28", "/repos/elhub/gh-dxp/releases/latest")
 	if err != nil {
 		return "", err
 	}
 
-	var decoded gitHubRelease
+	var deserializedResponse gitHubRelease
 
-	err = json.NewDecoder(&ret).Decode(&decoded)
+	err = json.NewDecoder(&response).Decode(&deserializedResponse)
 	if err != nil {
 		return "", err
 	}
 
-	if decoded.TagName == "" {
+	if deserializedResponse.TagName == "" {
 		return "", errors.New("response object contained no tag_name field")
 	}
 
-	return decoded.TagName, nil
+	return deserializedResponse.TagName, nil
 }
 
 // IsLatestVersion checks whether the provided version is the same as the latest release in GitHub.

--- a/pkg/utils/version_test.go
+++ b/pkg/utils/version_test.go
@@ -1,0 +1,87 @@
+package utils_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/elhub/gh-dxp/pkg/testutils"
+	"github.com/elhub/gh-dxp/pkg/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetLatestReleaseVersion(t *testing.T) {
+
+	ghAPIArgs := []string{"api", "-H", "Accept: application/vnd.github+json", "-H", "X-GitHub-Api-Version: 2022-11-28", "/repos/elhub/gh-dxp/releases/latest"}
+
+	t.Run("Latest release version is v1.2.3", func(t *testing.T) {
+		mockExe := new(testutils.MockExecutor)
+		mockExe.On("GH", ghAPIArgs).Return(`{"tag_name":"v1.2.3"}`, nil)
+
+		version, err := utils.GetLatestReleaseVersion(mockExe)
+
+		require.NoError(t, err)
+		assert.Equal(t, "v1.2.3", version)
+	})
+
+	t.Run("GitHub response is incorrectly formatted", func(t *testing.T) {
+		mockExe := new(testutils.MockExecutor)
+		mockExe.On("GH", ghAPIArgs).Return(`{"tag_name"v1.2.3"}`, nil)
+
+		_, err := utils.GetLatestReleaseVersion(mockExe)
+
+		require.Error(t, err)
+	})
+	t.Run("No tag_name in response", func(t *testing.T) {
+		mockExe := new(testutils.MockExecutor)
+		mockExe.On("GH", ghAPIArgs).Return(`{"other_field":"v1.2.3"}`, nil)
+
+		_, err := utils.GetLatestReleaseVersion(mockExe)
+
+		require.Error(t, err)
+	})
+
+}
+
+func TestIsLatestVersionOrSnapshot(t *testing.T) {
+	ghAPIArgs := []string{"api", "-H", "Accept: application/vnd.github+json", "-H", "X-GitHub-Api-Version: 2022-11-28", "/repos/elhub/gh-dxp/releases/latest"}
+
+	t.Run("Local version is SNAPSHOT", func(t *testing.T) {
+		mockExe := new(testutils.MockExecutor)
+
+		result, err := utils.IsLatestVersionOrSnapshot(mockExe, "SNAPSHOT")
+
+		require.NoError(t, err)
+		assert.Equal(t, true, result)
+	})
+	t.Run("Local version is not latest", func(t *testing.T) {
+		mockExe := new(testutils.MockExecutor)
+		mockExe.On("GH", ghAPIArgs).Return(`{"tag_name":"v1.2.3"}`, nil)
+
+		result, err := utils.IsLatestVersionOrSnapshot(mockExe, "v1.2.2")
+
+		assert.Equal(t, false, result)
+		require.NoError(t, err)
+
+	})
+	t.Run("Local version is latest", func(t *testing.T) {
+		mockExe := new(testutils.MockExecutor)
+		mockExe.On("GH", ghAPIArgs).Return(`{"tag_name":"v1.2.3"}`, nil)
+
+		result, err := utils.IsLatestVersionOrSnapshot(mockExe, "v1.2.3")
+
+		assert.Equal(t, true, result)
+		require.NoError(t, err)
+
+	})
+	t.Run("Error in api call", func(t *testing.T) {
+		mockExe := new(testutils.MockExecutor)
+		mockExe.On("GH", ghAPIArgs).Return("", errors.New("Some error"))
+
+		_, err := utils.IsLatestVersionOrSnapshot(mockExe, "v1.2.3")
+
+		require.Error(t, err)
+
+	})
+
+}


### PR DESCRIPTION
This diff contains two changes:
1) Add the gh dxp upgrade command, which will upgrade the extension to the latest version.
2) Add prerun check to all commands, and log a warning if the currently installed version is not equal to the latest version.

## 📋 Checklist

* ✅ Lint checks passed on local machine.
* ✅ Unit tests passed on local machine.
