### PR TITLE
Hide the upgrade command and change the outdated version prompt [patch]

### DIFF
--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -54,7 +54,7 @@ func GenerateCmd(settings *config.Settings, version string) (*cobra.Command, err
 		return nil, err
 	}
 	if !isLatestVersion {
-		log.Warn("You may be using an outdated version of gh dxp. Consider running 'gh dxp upgrade' to upgrade to the latest version.")
+		log.Warn("You may be using an outdated version of gh dxp. To upgrade to the latest version, you can run the following command: \n\n gh extension upgrade elhub/gh-dxp --force\n")
 	}
 
 	retCmd.AddCommand(

--- a/pkg/cmd/upgrade.go
+++ b/pkg/cmd/upgrade.go
@@ -10,9 +10,10 @@ import (
 // UpgradeCmd upgrades the dxp plugin to the latest version
 func UpgradeCmd(exe utils.Executor) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "upgrade",
-		Short: "Upgrade gh dxp",
-		Args:  cobra.ExactArgs(0),
+		Use:    "upgrade",
+		Short:  "Upgrade gh dxp",
+		Hidden: true,
+		Args:   cobra.ExactArgs(0),
 		Long: heredoc.Docf(`
 			Upgrade gh dxp to latest version`, "`"),
 		RunE: func(_ *cobra.Command, _ []string) error {


### PR DESCRIPTION
## 📝 Description

As I suspected, trying to 'hot-upgrade' the plugin using the plugin was triggering an error. This hides the upgrade command and changes the suggesed 'your version is outdated' comman

## 📋 Checklist

* ✅ Lint checks passed on local machine.
* ✅ Unit tests passed on local machine.
