### PR TITLE
Only log error in executor if output is not empty [patch]

### DIFF
--- a/pkg/utils/linuxexecutor.go
+++ b/pkg/utils/linuxexecutor.go
@@ -30,8 +30,11 @@ func (e *LinuxExecutorImpl) Command(name string, args ...string) (string, error)
 	log.Debug(fmt.Sprintf("Running '%s %s'", name, strings.Join(args, " ")))
 	cmd := e.ExecCommand(name, args...)
 	bytes, err := cmd.CombinedOutput()
-	if err != nil {
-		log.Error(string(bytes))
+
+	outputString := string(bytes)
+
+	if err != nil && outputString != "" {
+		log.Error(outputString)
 	}
 	return string(bytes), err
 }


### PR DESCRIPTION
## 📝 Description

When running the branch command, checking whether the chosen branch already exists is done by potentially triggering an error. Our current setup of logging stdout/stderr if subcommands return non-zero exit codes is thus triggered any time the branch does not exist, resulting in an empty error line being logged. If we end up with more of this case in the future, where the stderr is not empty, we may consider writing a different function for situations where we expect an error to ignore.

## 📋 Checklist

* ✅ Lint checks passed on local machine.
* ✅ Unit tests passed on local machine.
