### PR TITLE
Remove SECURITY.md

### DIFF
--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -61,11 +61,6 @@ func Execute(workingDir string, settings *config.Settings) error {
 			path:      filepath.Join(ghDir, "CONTRIBUTING.md"),
 			overwrite: true,
 		},
-		{
-			fileName:  ".github/SECURITY-template.md",
-			path:      filepath.Join(ghDir, "SECURITY.md"),
-			overwrite: true,
-		},
 	}
 
 	// Only write file if overwrite = true or file does not exist

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -29,7 +29,6 @@ func TestExecute(t *testing.T) {
 		filepath.Join(tempDir, "README.md"),
 		filepath.Join(tempDir, ".github/CODEOWNERS"),
 		filepath.Join(tempDir, ".github/CONTRIBUTING.md"),
-		filepath.Join(tempDir, ".github/SECURITY.md"),
 	}
 
 	// Execute the function


### PR DESCRIPTION
## 📝 Description

Revert the SECURITY.md change.
A SECURITY.md is now located in the elhub/.github repository. This security file is
default for all Elhub projects. Rather than having to maintain individual files in
each repository, it is better to just use this central version.

## 📋 Checklist

* ✅ Lint checks passed on local machine.
* ✅ Unit tests passed on local machine.
