### PR TITLE
Add ability to remove spinner final message [patch]

### DIFF
--- a/pkg/pr/prcreate.go
+++ b/pkg/pr/prcreate.go
@@ -80,10 +80,11 @@ func create(exe utils.Executor, options *CreateOptions, pr PullRequest) error {
 	// Push the current branch to git remote
 	s := utils.StartSpinner("Pushing current branch to remote...", "Pushed working branch to remote.")
 	currentBranch, err := exe.Command("git", "push", "--set-upstream", "origin", pr.branchID)
-	s.Stop()
 	if err != nil {
+		utils.RemoveFinalMsg(s)
 		return err
 	}
+	s.Stop()
 	log.Info("Current Branch:" + currentBranch + "\n")
 	newPR, err := createPR(exe, options, pr, options.baseBranch)
 	if err != nil {
@@ -94,10 +95,11 @@ func create(exe utils.Executor, options *CreateOptions, pr PullRequest) error {
 	args := []string{"pr", "create", "--title", newPR.Title, "--body", newPR.Body, "--base", options.baseBranch}
 	args = append(args, generatePRArgs(options)...)
 	stdOut, err := exe.GH(args...)
-	s.Stop()
 	if err != nil {
+		utils.RemoveFinalMsg(s)
 		return errors.Wrap(err, "Failed to create pull request")
 	}
+	s.Stop()
 	log.Info(strings.Trim(stdOut.String(), "\n"))
 
 	return nil
@@ -123,10 +125,11 @@ func update(exe utils.Executor, branchID string, prID string) error {
 	// Push the current branch to the already existing git remote
 	s := utils.StartSpinner("Updating Pull Request #"+prID+"...", "Pull Request #"+prID+" has been updated.")
 	_, err := exe.Command("git", "push")
-	s.Stop()
 	if err != nil {
+		utils.RemoveFinalMsg(s)
 		return err
 	}
+	s.Stop()
 
 	// Fetching this for info
 	stdOut, err := exe.GH("pr", "list", "-H", branchID, "--json", "url", "--jq", ".[].url")
@@ -372,10 +375,11 @@ func setBaseBranch(exe utils.Executor, options *CreateOptions) (string, error) {
 	if baseBranch == "" {
 		s := utils.StartSpinner("Fetching repository default branch...", "Fetched repository default branch")
 		stdOut, errV := exe.GH("repo", "view", "--json", "defaultBranchRef", "--jq", ".defaultBranchRef.name")
-		s.Stop()
 		if errV != nil {
+			utils.RemoveFinalMsg(s)
 			return "", errors.Wrap(errV, "Failed to fetch default branch")
 		}
+		s.Stop()
 		baseBranch = strings.Trim(stdOut.String(), "\n")
 		options.baseBranch = baseBranch
 	}

--- a/pkg/utils/spinner.go
+++ b/pkg/utils/spinner.go
@@ -22,3 +22,10 @@ func StartSpinner(msg string, finalMsg string) *spinner.Spinner {
 
 	return s
 }
+
+/*
+RemoveSpinnerFinalMsg removes the finalmsg from a spinner. This is intended to be used if an error occurs to prevent conflicting terminal output
+*/
+func RemoveSpinnerFinalMsg(s *spinner.Spinner) {
+	s.FinalMSG = ""
+}

--- a/pkg/utils/spinner.go
+++ b/pkg/utils/spinner.go
@@ -24,8 +24,8 @@ func StartSpinner(msg string, finalMsg string) *spinner.Spinner {
 }
 
 /*
-RemoveSpinnerFinalMsg removes the finalmsg from a spinner. This is intended to be used if an error occurs to prevent conflicting terminal output
+RemoveFinalMsg removes the finalmsg from a spinner. This is intended to be used if an error occurs to prevent conflicting terminal output
 */
-func RemoveSpinnerFinalMsg(s *spinner.Spinner) {
+func RemoveFinalMsg(s *spinner.Spinner) {
 	s.FinalMSG = ""
 }

--- a/pkg/utils/spinner_test.go
+++ b/pkg/utils/spinner_test.go
@@ -1,0 +1,31 @@
+package utils_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/elhub/gh-dxp/pkg/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStartSpinner(t *testing.T) {
+	suffix := "Suffix"
+	finalMsg := "Final Message"
+
+	t.Run("Spinner is created", func(t *testing.T) {
+
+		s := utils.StartSpinner(suffix, finalMsg)
+
+		assert.Equal(t, fmt.Sprintf(" %s", suffix), s.Suffix)
+		assert.Equal(t, fmt.Sprintf(" %s\n", finalMsg), s.FinalMSG)
+
+	})
+
+	t.Run("Spinner final message is correctly removed", func(t *testing.T) {
+
+		s := utils.StartSpinner(suffix, finalMsg)
+		utils.RemoveSpinnerFinalMsg(s)
+
+		assert.Empty(t, s.FinalMSG)
+	})
+}

--- a/pkg/utils/spinner_test.go
+++ b/pkg/utils/spinner_test.go
@@ -24,7 +24,7 @@ func TestStartSpinner(t *testing.T) {
 	t.Run("Spinner final message is correctly removed", func(t *testing.T) {
 
 		s := utils.StartSpinner(suffix, finalMsg)
-		utils.RemoveSpinnerFinalMsg(s)
+		utils.RemoveFinalMsg(s)
 
 		assert.Empty(t, s.FinalMSG)
 	})


### PR DESCRIPTION
The current spinner implementation has been unable to handle the situation where the underlying call fails in an elegant manner, leading to users reporting that they'll get conflicting messages such as "PR updated" while also seeing stderr output from an obviously failed command.

This diff seeks to remedy this by preventing the success message from being output if the underlying operation fails.

## 📋 Checklist

* ✅ Lint checks passed on local machine.
* ✅ Unit tests passed on local machine.
* ✅ This PR adds new tests.
