### PR TITLE
Enforce use of pr title and body in squash commit message when merging

### DIFF
--- a/pkg/pr/pr.go
+++ b/pkg/pr/pr.go
@@ -29,15 +29,25 @@ func CheckForExistingPR(exe utils.Executor, branchID string) (string, error) {
 
 // GetPRTitle gets the title of the current PR.
 func GetPRTitle(exe utils.Executor) (string, error) {
-	stdOut, err := exe.GH("pr", "view", "--json", "title", "--jq", ".title")
+	return getPRField(exe, "title")
+}
+
+// GetPRBody gets the body of the current PR.
+func GetPRBody(exe utils.Executor) (string, error) {
+	return getPRField(exe, "body")
+}
+
+// getPRField gets a single field of information about a PR using the gh pr command
+func getPRField(exe utils.Executor, field string) (string, error) {
+	stdOut, err := exe.GH("pr", "view", "--json", field, "--jq", "."+field)
 
 	if err != nil {
-		return "", errors.New("Error getting PR title")
+		return "", err
 	}
 
-	title := strings.Trim(stdOut.String(), "\n")
+	value := strings.Trim(stdOut.String(), "\n")
 
-	return title, nil
+	return value, nil
 }
 
 func handleUncommittedChanges(exe utils.Executor, options *Options) ([]string, error) {

--- a/pkg/pr/prmerge.go
+++ b/pkg/pr/prmerge.go
@@ -29,6 +29,11 @@ func ExecuteMerge(exe utils.Executor, options *MergeOptions) error {
 		return errTitle
 	}
 
+	prBody, errBody := GetPRBody(exe)
+	if errBody != nil {
+		return errBody
+	}
+
 	log.Info("Merging pull request #" + prID + "(" + prTitle + ")")
 	// TODO: Add list of commits
 	doMerge := false
@@ -47,7 +52,7 @@ func ExecuteMerge(exe utils.Executor, options *MergeOptions) error {
 		return nil
 	}
 
-	stdOut, err := exe.GH("pr", "merge", "--squash", "--delete-branch")
+	stdOut, err := exe.GH("pr", "merge", "--squash", "--delete-branch", "--subject", prTitle, "--body", prBody)
 	log.Info(stdOut.String())
 
 	if err != nil {

--- a/pkg/pr/prmerge_test.go
+++ b/pkg/pr/prmerge_test.go
@@ -19,6 +19,8 @@ func TestExecuteMerge(t *testing.T) {
 		prNumberErr   error
 		prTitle       string
 		prTitleErr    error
+		prBody        string
+		prBodyErr     error
 		prMerge       string
 		prMergeErr    error
 		expectedErr   error
@@ -28,6 +30,7 @@ func TestExecuteMerge(t *testing.T) {
 			pushBranch:  "branch1",
 			prNumber:    "3",
 			prTitle:     "PR title",
+			prBody:      "PR body",
 			prMerge:     "pull request merged",
 			expectedErr: nil,
 		},
@@ -67,7 +70,8 @@ func TestExecuteMerge(t *testing.T) {
 			mockExe.On("GH", []string{"pr", "list", "-H", tt.pushBranch, "--json", "number", "--jq", ".[].number"}).
 				Return(tt.prNumber, tt.prNumberErr)
 			mockExe.On("GH", []string{"pr", "view", "--json", "title", "--jq", ".title"}).Return(tt.prTitle, tt.prTitleErr)
-			mockExe.On("GH", []string{"pr", "merge", "--squash", "--delete-branch"}).Return(tt.prMerge, tt.prMergeErr)
+			mockExe.On("GH", []string{"pr", "view", "--json", "body", "--jq", ".body"}).Return(tt.prBody, tt.prBodyErr)
+			mockExe.On("GH", []string{"pr", "merge", "--squash", "--delete-branch", "--subject", tt.prTitle, "--body", tt.prBody}).Return(tt.prMerge, tt.prMergeErr)
 
 			err := pr.ExecuteMerge(mockExe, &pr.MergeOptions{
 				AutoConfirm: true,


### PR DESCRIPTION
Some users have reported that when merging pr's the resulting commit message is the first commit message of the branch, and not the PR title as is intended. This is default behaviour in GitHub.

This change aims to ensure that the pr merge command will always use the PR title and body, even if there is only one commit in the branch.

## 📋 Checklist

* ✅ Lint checks passed on local machine.
* ✅ Unit tests passed on local machine.
