### PR TITLE
Refactor executor GH return type from byte.buffer to string [patch]

### DIFF
--- a/pkg/pr/pr.go
+++ b/pkg/pr/pr.go
@@ -21,7 +21,7 @@ func CheckForExistingPR(exe utils.Executor, branchID string) (string, error) {
 		return "", errors.New("Failed to find existing PR")
 	}
 
-	number := strings.Trim(stdOut.String(), "\n")
+	number := strings.Trim(stdOut, "\n")
 
 	return number, nil
 }
@@ -44,7 +44,7 @@ func getPRField(exe utils.Executor, field string) (string, error) {
 		return "", err
 	}
 
-	value := strings.Trim(stdOut.String(), "\n")
+	value := strings.Trim(stdOut, "\n")
 
 	return value, nil
 }

--- a/pkg/pr/prcreate.go
+++ b/pkg/pr/prcreate.go
@@ -100,7 +100,7 @@ func create(exe utils.Executor, options *CreateOptions, pr PullRequest) error {
 		return errors.Wrap(err, "Failed to create pull request")
 	}
 	s.Stop()
-	log.Info(strings.Trim(stdOut.String(), "\n"))
+	log.Info(strings.Trim(stdOut, "\n"))
 
 	return nil
 }
@@ -137,7 +137,7 @@ func update(exe utils.Executor, branchID string, prID string) error {
 		return err
 	}
 
-	log.Info(strings.Trim(stdOut.String(), "\n") + "\n")
+	log.Info(strings.Trim(stdOut, "\n") + "\n")
 
 	return nil
 }
@@ -380,7 +380,7 @@ func setBaseBranch(exe utils.Executor, options *CreateOptions) (string, error) {
 			return "", errors.Wrap(errV, "Failed to fetch default branch")
 		}
 		s.Stop()
-		baseBranch = strings.Trim(stdOut.String(), "\n")
+		baseBranch = strings.Trim(stdOut, "\n")
 		options.baseBranch = baseBranch
 	}
 	return baseBranch, nil

--- a/pkg/pr/prmerge.go
+++ b/pkg/pr/prmerge.go
@@ -53,7 +53,7 @@ func ExecuteMerge(exe utils.Executor, options *MergeOptions) error {
 	}
 
 	stdOut, err := exe.GH("pr", "merge", "--squash", "--delete-branch", "--subject", prTitle, "--body", prBody)
-	log.Info(stdOut.String())
+	log.Info(stdOut)
 
 	if err != nil {
 		log.Debug("Error: " + err.Error())

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -50,7 +50,7 @@ func Execute(exe utils.Executor, opts *Options) error {
 		if err != nil {
 			return err
 		}
-		statusReport.WriteString(fmt.Sprintf("PR Status:\n%s\n", prStatus.String()))
+		statusReport.WriteString(fmt.Sprintf("PR Status:\n%s\n", prStatus))
 	}
 
 	if opts.All || opts.Branches {
@@ -66,7 +66,7 @@ func Execute(exe utils.Executor, opts *Options) error {
 		if err != nil {
 			return err
 		}
-		statusReport.WriteString(fmt.Sprintf("Assigned PRs/Review Requests:\n%s\n", assignedPRs.String()))
+		statusReport.WriteString(fmt.Sprintf("Assigned PRs/Review Requests:\n%s\n", assignedPRs))
 	}
 
 	log.Info(statusReport.String())

--- a/pkg/testutils/mockexecutor.go
+++ b/pkg/testutils/mockexecutor.go
@@ -1,7 +1,6 @@
 package testutils
 
 import (
-	"bytes"
 	"context"
 
 	"github.com/stretchr/testify/mock"
@@ -25,9 +24,9 @@ func (m *MockExecutor) CommandContext(ctx context.Context, name string, arg ...s
 }
 
 // GH pretends to run a GitHub CLI command and returns its output.
-func (m *MockExecutor) GH(arg ...string) (bytes.Buffer, error) {
+func (m *MockExecutor) GH(arg ...string) (string, error) {
 	args := m.Called(arg)
-	return *bytes.NewBufferString(args.String(0)), args.Error(1)
+	return args.String(0), args.Error(1)
 }
 
 // Chdir pretends to change the current working directory.

--- a/pkg/testutils/mockexecutor_test.go
+++ b/pkg/testutils/mockexecutor_test.go
@@ -49,7 +49,7 @@ func TestNewMockExecutor(t *testing.T) {
 	// Test GH method
 	ghOutput, err := mockExe.GH("repo", "view")
 	assert.NoError(t, err)
-	assert.Equal(t, "mocked output", ghOutput.String())
+	assert.Equal(t, "mocked output", ghOutput)
 
 	// Test Chdir method
 	err = mockExe.Chdir("/mock/path")

--- a/pkg/utils/executor.go
+++ b/pkg/utils/executor.go
@@ -2,7 +2,6 @@
 package utils
 
 import (
-	"bytes"
 	"context"
 )
 
@@ -10,6 +9,6 @@ import (
 type Executor interface {
 	Command(name string, args ...string) (string, error)
 	CommandContext(ctx context.Context, name string, arg ...string) error
-	GH(args ...string) (bytes.Buffer, error)
+	GH(args ...string) (string, error)
 	Chdir(dir string) error
 }

--- a/pkg/utils/linuxexecutor.go
+++ b/pkg/utils/linuxexecutor.go
@@ -2,7 +2,6 @@
 package utils
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -51,15 +50,15 @@ func (e *LinuxExecutorImpl) CommandContext(ctx context.Context, name string, arg
 }
 
 // GH runs a GitHub CLI command and returns its output.
-func (e *LinuxExecutorImpl) GH(args ...string) (bytes.Buffer, error) {
+func (e *LinuxExecutorImpl) GH(args ...string) (string, error) {
 	log.Debug(fmt.Sprintf("Running gh '%s'", strings.Join(args, " ")))
 	stdOut, stdErr, err := gh.Exec(args...)
 	if err != nil {
 		log.Error(stdErr.String())
 		log.Debug(fmt.Sprintf("Error running GH command: %s", err.Error()))
-		return stdErr, err
+		return stdErr.String(), err
 	}
-	return stdOut, err
+	return stdOut.String(), err
 }
 
 // Chdir changes the current working directory.

--- a/pkg/utils/version.go
+++ b/pkg/utils/version.go
@@ -15,7 +15,7 @@ func GetLatestReleaseVersion(exe Executor) (string, error) {
 
 	var deserializedResponse gitHubRelease
 
-	err = json.NewDecoder(&response).Decode(&deserializedResponse)
+	err = json.Unmarshal([]byte(response), &deserializedResponse)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## 📝 Description

The Executor interface has been somewhat inconsistent in its signature. When using the Command method, the return type has been (string, error) - while GH has had (byte.buffer, error). Furthermore, the codebase has been seeing an increasing number of lines simply casting the byte buffer to a string upon reception, prompting me to change the return type to string for consistency and chillness.

## 📋 Checklist

* ✅ Lint checks passed on local machine.
* ✅ Unit tests passed on local machine.
