### PR TITLE
Add clone-all functionality to gh-dxp

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,87 @@
+# Contributing
+
+So you want to contribute ? Awesome. ❤️
+
+All types of contributions are encouraged and valued.  See below for different ways to help and details about how
+this project handles them. Please make sure to read the relevant section before making your contribution. It will
+make it a lot easier for us maintainers and smooth out the experience for everyone involved. We look forward to
+your contributions. 🎉
+
+> If you like the project, but just don't have time to contribute, that's fine. There are other easy ways to support
+> the project and show your appreciation, which we would also be very happy about:
+>
+> * Star the project
+> * Refer this project in your project's readme
+> * Mention the project on social media, meetups, etc.
+
+## Code of Conduct
+
+We adhere to the [Contributor Covenant Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+By participating, you are expected to uphold this code.
+
+## Issue Tracker
+
+Elhub employees should generally use our internal Jira instance (follow the link in the [README](../README.md));
+everyone else is welcome to [open an issue on GitHub](/issues/).
+
+When writing issues:
+
+* Ensure you are running on the latest version.
+* Always check whether there is a previous, similar issue. If there is, consider commenting on that issue rather
+  than opening an entirely new issue.
+* Provide as much context as you can about what you're running into. Describe what you're observing and what you
+  expected, steps to reproduce the issue, technical details, etc.
+
+> Do not, **ever**, report security related issues, vulnerabilities or bugs including sensitive information to the
+> public issue tracker or elsewhere in public. For sensitive bugs, <email:security@elhub.no>.
+
+## I Have a Question
+
+> If you want to ask a question, we assume that you have read the available documentation (start with ../README.md).
+
+Post your question as a new issue or comment on an existing suitable issue.
+
+We will try to respond as soon as possible.
+
+## I Want To Contribute
+
+> ### Legal Notice
+> When contributing to this project, you must agree that you have authored 100% of the content, that you have the
+> necessary rights to the content and that the content you contribute may be provided under the project license.
+
+### Reporting Bugs
+
+Before submitting a bug report, please investigate as much as you can beforehand, focusing especially on isolating
+the problem and understanding how to recreate it. Then submit the bug in the [issue tracker](#issue-tracker).
+
+### Suggesting Enhancements
+
+Before submitting an enhancement, consider whether the idea fits within the scope and aims of the project.
+[Asking a question](#i-have-a-question) can be a good starting point. Then submit the enchancement as a suggestion
+through the [issue tracker](#issue-tracker).
+
+### Your First Code Contribution
+
+Ideally, use our GitHub CLI extension ([gh-dxp](https://github.com/elhub/gh-dxp)) to enforce linting/style rules
+and format your pull request. Otherwise, use our
+[pull request template](https://github.com/elhub/devxp-project-template/blob/main/resources/.github/pull_request_template.md)
+as a starting point.
+
+The title should use present tense ("Add feature" not "Added feature") and use the imperative mood.
+
+All our code is linted with [MegaLinter](https://megalinter.io). To run linting manually, use:
+
+```bash
+npx mega-linter-runner --install
+npx mega-linter-runner --flavor cupcake -e MEGALINTER_CONFIG=https://raw.githubusercontent.com/elhub/devxp-lint-configuration/main/resources/.mega-linter.yml
+```
+
+To run the local tests, check the [README](../README.md).
+
+Providing linted _and_ tested code significantly increases the chance that a pull request will be accepted.
+
+### Improving The Documentation
+
+Markdown is our format of preference for all documentation. Submitting new or corrections to documentation follow the
+same procedure as for code. You do not need to run unit tests on documentation, but you should run the linter (which
+includes [markdownlint](https://github.com/DavidAnson/markdownlint)).

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@
 pyproject.toml
 revive.toml
 trivy.yaml
+checkstyle-config.xml
+java-pmd-ruleset.xml
 
 ### Ansible ###
 **/galaxy/*
@@ -88,6 +90,35 @@ buildNumber.properties
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
+### Python ###
+.venv
+__pycache__/
+*.py[cod]
+*$py.class
+# Distribution / packaging
+.Python
+build/
+dist/
+wheels/
+share/python-wheels/
+*.egg-info/
+*.egg
+MANIFEST
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
 ### React ###
 .DS_*
 dist/
@@ -119,3 +150,9 @@ terraform/*.tfvars
 ### Visual Studio Code ###
 .vscode/
 *.code-workspace
+
+### Helm ###
+# Chart dependencies
+**/charts/*.tgz
+# Avoid commiting chart lockfile (can cause issues with ArgoCD)
+Chart.lock

--- a/alias.yml
+++ b/alias.yml
@@ -15,3 +15,6 @@ prl: dxp pr list
 prm: dxp pr merge
 pru: dxp pr update
 prv: pr view
+
+# Repos
+cla: dxp repo clone-all

--- a/alias.yml
+++ b/alias.yml
@@ -17,4 +17,4 @@ pru: dxp pr update
 prv: pr view
 
 # Repos
-cla: dxp repo clone-all
+rcl: dxp repo clone-all

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -100,3 +100,25 @@ gh dxp pr create -b branchName -m "Add amazing new feature"
 ### pr merge
 
 The `pr merge` command handles the merging of diffs/pull requests.
+
+
+## repo
+
+The `repo` command extends .
+
+### repo clone-all
+
+The `repo clone-all` command allows you to clone some or all repositories within an organization.
+
+### Example usage
+
+```bash
+# Clone all repositories from all organization you have access to.
+gh dxp repo clone-all
+
+# Clone all repositories that contain "docs"
+gh dxp repo clone-all docs
+
+# List the repositories that would be cloned using this command
+gh dxp repo clone-all docs --dryrun
+```

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -15,7 +15,7 @@ This document contains documentation for the various commands implemented in `gh
 In order to simplify usage, we have defined a default `alias.yml` that defines the most commonly used workflow
 commands. The `alias` command downloads and imports this default file.
 
-Example:
+**Example:**
 
 ```bash
 gh dxp alias import
@@ -84,7 +84,7 @@ The `pr` command handles all things related to pull requests.
 The `pr create` command allows you to create and update diffs/pull requests. By default, it will run both `lint` and
 `test` as steps.
 
-### Example usage
+**Example:**
 
 ```bash
 # Start flow to create pr
@@ -110,7 +110,7 @@ The `repo` command extends .
 
 The `repo clone-all` command allows you to clone some or all repositories within an organization.
 
-### Example usage
+**Example:**
 
 ```bash
 # Clone all repositories from all organization you have access to.

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -7,7 +7,8 @@ tags: [github, reference]
 This document contains documentation for the various commands implemented in `gh-dxp`.
 
 !!! tip
-    You can run any command with the `--help` flag to get more information on how it works.
+    You can run any command with the `--help` flag to get more information on how it works. There are lots of
+    useful options that are not documented on these pages.
 
 
 ## alias

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -56,6 +56,7 @@ func GenerateCmd(settings *config.Settings, version string) (*cobra.Command, err
 		LintCmd(exe, settings),
 		OwnerCmd(exe, settings),
 		PRCmd(exe, settings),
+		RepoCmd(exe, settings),
 		TestCmd(exe),
 		TemplateCmd(exe, settings),
 		StatusCmd(exe),

--- a/pkg/cmd/repo.go
+++ b/pkg/cmd/repo.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"github.com/MakeNowJust/heredoc"
+	"github.com/elhub/gh-dxp/pkg/config"
+	"github.com/elhub/gh-dxp/pkg/repo"
+	"github.com/elhub/gh-dxp/pkg/utils"
+	"github.com/spf13/cobra"
+)
+
+// RepoCmd extends the functionality of the gh repo command.
+func RepoCmd(exe utils.Executor, _ *config.Settings) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "repo",
+		Short: "Work with Repositories",
+		Long: heredoc.Doc(`
+			The repo command group extends the basic repo commands provided by the
+			standard GitHub CLI commands with some extra bells and whistles useful for
+			handling a set of repositories.
+		`),
+	}
+
+	cmd.AddCommand(RepoCloneCmd(exe))
+
+	return cmd
+}
+
+// RepoCloneCmd creates a new command to clone all repositories (or just those with a given name).
+func RepoCloneCmd(exe utils.Executor) *cobra.Command {
+	opts := &repo.Options{}
+
+	cmd := &cobra.Command{
+		Use:   "clone-all [<pattern>]",
+		Short: "Clone all repositories with a given name.",
+		Long: heredoc.Docf(`
+			Clones all repositories with a given name pattern. If no pattern is provided,
+			clone all repositories from the user's organizations.
+		`, "`"),
+		Example: heredoc.Doc(`
+			# Clone everything
+			$ gh dxp repo clone-all
+
+			# Clone all repositories in any of your organizations starting with gh
+			$ gh dxp repo clone-all gh
+
+			# Check what repositories would be cloned
+			$ gh dxp repo clone-all gh --dryrun
+		`),
+		RunE: func(_ *cobra.Command, args []string) error {
+			pattern := ""
+			if len(args) > 0 {
+				pattern = args[0]
+			}
+			return repo.ExecuteClone(exe, pattern, opts)
+		},
+	}
+
+	fl := cmd.Flags()
+	fl.BoolVar(
+		&opts.DryRun,
+		"dryrun",
+		false,
+		"Do not actually clone the repositories, just list the repositories that would be cloned.",
+	)
+
+	return cmd
+}

--- a/pkg/repo/model.go
+++ b/pkg/repo/model.go
@@ -1,0 +1,6 @@
+package repo
+
+// Options represents the options for the pr command.
+type Options struct {
+	DryRun bool
+}

--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -1,0 +1,100 @@
+package repo
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/caarlos0/log"
+	"github.com/elhub/gh-dxp/pkg/utils"
+	"github.com/pkg/errors"
+)
+
+type repositoryInfo struct {
+	Name     string `json:"name"`
+	FullName string `json:"fullName"`
+	URL      string `json:"url"`
+}
+
+// ExecuteClone carries out a clone all on the given pattern
+func ExecuteClone(exe utils.Executor, pattern string, opts *Options) error {
+	repositoryInfo, err := retrieveRepositories(pattern, exe)
+	if err != nil {
+		return err
+	}
+
+	for _, repo := range repositoryInfo {
+		// If directory exits, skip cloning
+		exists, err := utils.DirectoryExists(repo.Name)
+		if err != nil {
+			return errors.Wrap(err, "failed to check if directory exists")
+		}
+
+		if !exists {
+			if opts.DryRun {
+				log.Infof("Dry run: Clone repository %s", repo.FullName)
+			} else {
+				log.Infof("Cloning repository: %s", repo.FullName)
+				_, err := exe.GH("repo", "clone", repo.FullName)
+				if err != nil {
+					log.Debug(err.Error())
+				}
+			}
+		} else {
+			log.Infof("Skipped cloning of repository %s as directory already exists", repo.FullName)
+		}
+	}
+
+	return nil
+}
+
+func retrieveUserOrgs(exe utils.Executor) ([]string, error) {
+	type Org struct {
+		Login string `json:"login"`
+	}
+
+	res, err := exe.GH("api", "user/orgs")
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to retrieve user organizations")
+	}
+
+	var orgs []Org
+	err = json.Unmarshal([]byte(res), &orgs)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal user organizations")
+	}
+
+	var orgLogins []string
+	for _, org := range orgs {
+		orgLogins = append(orgLogins, org.Login)
+	}
+	return orgLogins, nil
+}
+
+func retrieveRepositories(pattern string, exe utils.Executor) ([]repositoryInfo, error) {
+	orgs, err := retrieveUserOrgs(exe)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to retrieve user organizations")
+	}
+	// Convert to comma separated string
+	orgsStr := strings.Join(orgs, ",")
+	log.Infof("Searching for repositories in the following organizations: %s", orgsStr)
+
+	var res string
+	if len(pattern) == 0 {
+		res, err = exe.GH("search", "repos", "--archived=false", "--json", "name,fullName,url", "--limit=1000", "--owner", orgsStr)
+	} else {
+		res, err = exe.GH("search", "repos", pattern, "--match", "name", "--archived=false", "--json", "name,fullName,url", "--limit=1000", "--owner", orgsStr)
+	}
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to search repositories")
+	}
+
+	var searchResults []repositoryInfo
+	err = json.Unmarshal([]byte(res), &searchResults)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal search results for repositories")
+	}
+	log.Infof("Found %d repositories matching the pattern %s", len(searchResults), pattern)
+
+	return searchResults, nil
+}

--- a/pkg/repo/repo_test.go
+++ b/pkg/repo/repo_test.go
@@ -1,0 +1,58 @@
+package repo_test
+
+import (
+	"testing"
+
+	"github.com/elhub/gh-dxp/pkg/repo"
+	"github.com/elhub/gh-dxp/pkg/testutils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRun_ExecuteClone(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		options *repo.Options
+	}{
+		{
+			name:    "Clone all without dryrun",
+			pattern: "",
+			options: &repo.Options{DryRun: false},
+		},
+		{
+			name:    "Clone all with dryrun",
+			pattern: "",
+			options: &repo.Options{DryRun: true},
+		},
+		{
+			name:    "Clone with pattern without dryrun",
+			pattern: "repo",
+			options: &repo.Options{DryRun: false},
+		},
+		{
+			name:    "Clone with pattern with dryrun",
+			pattern: "repo",
+			options: &repo.Options{DryRun: true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockExe := new(testutils.MockExecutor)
+			mockExe.On("GH", []string{"api", "user/orgs"}).Return(`[{"login": "myorg","id": 3679327}]`, nil)
+			if tt.pattern == "" {
+				mockExe.On("GH", []string{"search", "repos", "--archived=false", "--json", "name,fullName,url", "--limit=1000", "--owner", "myorg"}).Return(`[{"name": "repo1", "fullName": "myorg/repo1", "url": "https://github.com/myorg/repo1"}, {"name": "repo2", "fullName": "myorg/repo2", "url": "https://github.com/myorg/repo2"}]`, nil)
+			} else {
+				mockExe.On("GH", []string{"search", "repos", tt.pattern, "--match", "name", "--archived=false", "--json", "name,fullName,url", "--limit=1000", "--owner", "myorg"}).Return(`[{"name": "repo1", "fullName": "myorg/repo1", "url": "https://github.com/myorg/repo1"}, {"name": "repo2", "fullName": "myorg/repo2", "url": "https://github.com/myorg/repo2"}]`, nil)
+			}
+			if !tt.options.DryRun { // If not dry run, we expect the repos to be cloned
+				mockExe.On("GH", []string{"repo", "clone", "myorg/repo1"}).Return("", nil)
+				mockExe.On("GH", []string{"repo", "clone", "myorg/repo2"}).Return("", nil)
+			}
+
+			err := repo.ExecuteClone(mockExe, tt.pattern, tt.options)
+			assert.NoError(t, err)
+			mockExe.AssertExpectations(t)
+		})
+	}
+}

--- a/pkg/utils/directory.go
+++ b/pkg/utils/directory.go
@@ -1,8 +1,23 @@
 package utils
 
 import (
+	"errors"
+	"io/fs"
+	"os"
 	"strings"
 )
+
+// DirectoryExists checks whether a directory exists.
+func DirectoryExists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, fs.ErrNotExist) {
+		return false, nil
+	}
+	return false, err
+}
 
 // GetGitRootDirectory returns the root directory of the current git repo.
 func GetGitRootDirectory(exe Executor) (string, error) {


### PR DESCRIPTION
## 📝 Description

This adds a new clone-all command. Due to issues we have noted with the API,
this does not try to parallelize clones; everything is done sequentially to keep
things simple.

Currently this grabs everything that the user has access to. An --owner or--organization
option should probably be introduced to allow the user to limit which organization
repos are cloned.

## 🔗 Issue ID(s): TDX-741

## 📋 Checklist

* ✅ Lint checks passed on local machine.
* ✅ Unit tests passed on local machine.
* ✅ This PR adds new tests.
