### PR TITLE
Set linter rules path to /tmp

### DIFF
--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -24,6 +24,8 @@ func Run(exe utils.Executor, _ *config.Settings, opts *Options) error {
 		args = append(args, "--image", opts.LinterImage)
 	}
 
+	args = append(args, "-e", "LINTER_RULES_PATH=tmp/") // Prevents mega-linter from spamming lint configuration files into the repository
+
 	// Check if mega-lint configuration is present in the repository.
 	if !utils.FileExists(".mega-linter.yml") {
 		log.Info("Using the default Elhub mega-linter configuration.\n")

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -24,7 +24,7 @@ func Run(exe utils.Executor, _ *config.Settings, opts *Options) error {
 		args = append(args, "--image", opts.LinterImage)
 	}
 
-	args = append(args, "-e", "LINTER_RULES_PATH=tmp/") // Prevents mega-linter from spamming lint configuration files into the repository
+	args = append(args, "-e", "LINTER_RULES_PATH=/tmp") // Prevents mega-linter from spamming lint configuration files into the repository
 
 	// Check if mega-lint configuration is present in the repository.
 	if !utils.FileExists(".mega-linter.yml") {

--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -18,7 +18,7 @@ func TestRun_LintNoErrors(t *testing.T) {
 
 	linterArgs := []string{
 		"mega-linter-runner", "--flavor", "cupcake",
-		"-e", "LINTER_RULES_PATH=tmp/",
+		"-e", "LINTER_RULES_PATH=/tmp",
 		"-e", "MEGALINTER_CONFIG=https://raw.githubusercontent.com/elhub/devxp-lint-configuration/main/resources/.mega-linter.yml",
 		"--filesonly", "/pkg/source.go", "/pkg/source2.go",
 	}
@@ -37,7 +37,7 @@ func TestRun_LintHasErrors(t *testing.T) {
 
 	linterArgs := []string{
 		"mega-linter-runner", "--flavor", "cupcake",
-		"-e", "LINTER_RULES_PATH=tmp/",
+		"-e", "LINTER_RULES_PATH=/tmp",
 		"-e", "MEGALINTER_CONFIG=https://raw.githubusercontent.com/elhub/devxp-lint-configuration/main/resources/.mega-linter.yml",
 		"--filesonly", "/pkg/source.go", "/pkg/source2.go",
 	}
@@ -54,7 +54,7 @@ func TestRun_LintAllFiles(t *testing.T) {
 
 	linterArgs := []string{
 		"mega-linter-runner", "--flavor", "cupcake",
-		"-e", "LINTER_RULES_PATH=tmp/",
+		"-e", "LINTER_RULES_PATH=/tmp",
 		"-e", "MEGALINTER_CONFIG=https://raw.githubusercontent.com/elhub/devxp-lint-configuration/main/resources/.mega-linter.yml",
 	}
 
@@ -72,7 +72,7 @@ func TestRun_LintWithFix(t *testing.T) {
 
 	linterArgs := []string{
 		"mega-linter-runner", "--flavor", "cupcake",
-		"-e", "LINTER_RULES_PATH=tmp/",
+		"-e", "LINTER_RULES_PATH=/tmp",
 		"-e", "MEGALINTER_CONFIG=https://raw.githubusercontent.com/elhub/devxp-lint-configuration/main/resources/.mega-linter.yml",
 		"--filesonly", "/pkg/source.go", "/pkg/source2.go", "--fix",
 	}
@@ -91,7 +91,7 @@ func TestRun_LintWithNoExistingBranches(t *testing.T) {
 
 	linterArgs := []string{
 		"mega-linter-runner", "--flavor", "cupcake",
-		"-e", "LINTER_RULES_PATH=tmp/",
+		"-e", "LINTER_RULES_PATH=/tmp",
 		"-e", "MEGALINTER_CONFIG=https://raw.githubusercontent.com/elhub/devxp-lint-configuration/main/resources/.mega-linter.yml",
 		"--filesonly", "/pkg/source.go", "/pkg/source2.go",
 	}
@@ -108,7 +108,7 @@ func TestRun_LintSpecificDirectory(t *testing.T) {
 
 	linterArgs := []string{
 		"mega-linter-runner", "--flavor", "cupcake",
-		"-e", "LINTER_RULES_PATH=tmp/",
+		"-e", "LINTER_RULES_PATH=/tmp",
 		"-e", "MEGALINTER_CONFIG=https://raw.githubusercontent.com/elhub/devxp-lint-configuration/main/resources/.mega-linter.yml",
 		"-e", "FILTER_REGEX_INCLUDE=(pkg)",
 	}
@@ -125,7 +125,7 @@ func TestRun_UseProxy(t *testing.T) {
 
 	linterArgs := []string{
 		"mega-linter-runner", "--flavor", "cupcake",
-		"-e", "LINTER_RULES_PATH=tmp/",
+		"-e", "LINTER_RULES_PATH=/tmp",
 		"-e", "MEGALINTER_CONFIG=https://raw.githubusercontent.com/elhub/devxp-lint-configuration/main/resources/.mega-linter.yml",
 		"-e", "FILTER_REGEX_INCLUDE=(pkg)", "-e", "https_proxy=https://myproxy.no:8080",
 	}

--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -17,8 +17,9 @@ func TestRun_LintNoErrors(t *testing.T) {
 	mockExe.On("Command", "git", []string{"diff", "--name-only", "main", "--relative"}).Return("/pkg/source.go\n/pkg/source2.go", nil)
 
 	linterArgs := []string{
-		"mega-linter-runner", "--flavor", "cupcake", "-e",
-		"MEGALINTER_CONFIG=https://raw.githubusercontent.com/elhub/devxp-lint-configuration/main/resources/.mega-linter.yml",
+		"mega-linter-runner", "--flavor", "cupcake",
+		"-e", "LINTER_RULES_PATH=tmp/",
+		"-e", "MEGALINTER_CONFIG=https://raw.githubusercontent.com/elhub/devxp-lint-configuration/main/resources/.mega-linter.yml",
 		"--filesonly", "/pkg/source.go", "/pkg/source2.go",
 	}
 
@@ -35,8 +36,9 @@ func TestRun_LintHasErrors(t *testing.T) {
 	mockExe.On("Command", "git", []string{"diff", "--name-only", "main", "--relative"}).Return("/pkg/source.go\n/pkg/source2.go", nil)
 
 	linterArgs := []string{
-		"mega-linter-runner", "--flavor", "cupcake", "-e",
-		"MEGALINTER_CONFIG=https://raw.githubusercontent.com/elhub/devxp-lint-configuration/main/resources/.mega-linter.yml",
+		"mega-linter-runner", "--flavor", "cupcake",
+		"-e", "LINTER_RULES_PATH=tmp/",
+		"-e", "MEGALINTER_CONFIG=https://raw.githubusercontent.com/elhub/devxp-lint-configuration/main/resources/.mega-linter.yml",
 		"--filesonly", "/pkg/source.go", "/pkg/source2.go",
 	}
 
@@ -51,8 +53,9 @@ func TestRun_LintAllFiles(t *testing.T) {
 	mockExe := new(testutils.MockExecutor)
 
 	linterArgs := []string{
-		"mega-linter-runner", "--flavor", "cupcake", "-e",
-		"MEGALINTER_CONFIG=https://raw.githubusercontent.com/elhub/devxp-lint-configuration/main/resources/.mega-linter.yml",
+		"mega-linter-runner", "--flavor", "cupcake",
+		"-e", "LINTER_RULES_PATH=tmp/",
+		"-e", "MEGALINTER_CONFIG=https://raw.githubusercontent.com/elhub/devxp-lint-configuration/main/resources/.mega-linter.yml",
 	}
 
 	mockExe.On("CommandContext", mock.Anything, "npx", linterArgs).Return(nil, nil)
@@ -68,8 +71,9 @@ func TestRun_LintWithFix(t *testing.T) {
 	mockExe.On("Command", "git", []string{"diff", "--name-only", "main", "--relative"}).Return("/pkg/source.go\n/pkg/source2.go", nil)
 
 	linterArgs := []string{
-		"mega-linter-runner", "--flavor", "cupcake", "-e",
-		"MEGALINTER_CONFIG=https://raw.githubusercontent.com/elhub/devxp-lint-configuration/main/resources/.mega-linter.yml",
+		"mega-linter-runner", "--flavor", "cupcake",
+		"-e", "LINTER_RULES_PATH=tmp/",
+		"-e", "MEGALINTER_CONFIG=https://raw.githubusercontent.com/elhub/devxp-lint-configuration/main/resources/.mega-linter.yml",
 		"--filesonly", "/pkg/source.go", "/pkg/source2.go", "--fix",
 	}
 
@@ -86,8 +90,9 @@ func TestRun_LintWithNoExistingBranches(t *testing.T) {
 	mockExe.On("Command", "git", []string{"status", "--porcelain"}).Return(" M /pkg/source.go\n M /pkg/source2.go", nil)
 
 	linterArgs := []string{
-		"mega-linter-runner", "--flavor", "cupcake", "-e",
-		"MEGALINTER_CONFIG=https://raw.githubusercontent.com/elhub/devxp-lint-configuration/main/resources/.mega-linter.yml",
+		"mega-linter-runner", "--flavor", "cupcake",
+		"-e", "LINTER_RULES_PATH=tmp/",
+		"-e", "MEGALINTER_CONFIG=https://raw.githubusercontent.com/elhub/devxp-lint-configuration/main/resources/.mega-linter.yml",
 		"--filesonly", "/pkg/source.go", "/pkg/source2.go",
 	}
 
@@ -102,8 +107,9 @@ func TestRun_LintSpecificDirectory(t *testing.T) {
 	mockExe := new(testutils.MockExecutor)
 
 	linterArgs := []string{
-		"mega-linter-runner", "--flavor", "cupcake", "-e",
-		"MEGALINTER_CONFIG=https://raw.githubusercontent.com/elhub/devxp-lint-configuration/main/resources/.mega-linter.yml",
+		"mega-linter-runner", "--flavor", "cupcake",
+		"-e", "LINTER_RULES_PATH=tmp/",
+		"-e", "MEGALINTER_CONFIG=https://raw.githubusercontent.com/elhub/devxp-lint-configuration/main/resources/.mega-linter.yml",
 		"-e", "FILTER_REGEX_INCLUDE=(pkg)",
 	}
 
@@ -118,8 +124,9 @@ func TestRun_UseProxy(t *testing.T) {
 	mockExe := new(testutils.MockExecutor)
 
 	linterArgs := []string{
-		"mega-linter-runner", "--flavor", "cupcake", "-e",
-		"MEGALINTER_CONFIG=https://raw.githubusercontent.com/elhub/devxp-lint-configuration/main/resources/.mega-linter.yml",
+		"mega-linter-runner", "--flavor", "cupcake",
+		"-e", "LINTER_RULES_PATH=tmp/",
+		"-e", "MEGALINTER_CONFIG=https://raw.githubusercontent.com/elhub/devxp-lint-configuration/main/resources/.mega-linter.yml",
 		"-e", "FILTER_REGEX_INCLUDE=(pkg)", "-e", "https_proxy=https://myproxy.no:8080",
 	}
 

--- a/pkg/pr/prcreate_test.go
+++ b/pkg/pr/prcreate_test.go
@@ -225,8 +225,9 @@ func TestExecuteCreate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			linterArgs := []string{"mega-linter-runner", "--flavor", "cupcake", "-e",
-				"MEGALINTER_CONFIG=https://raw.githubusercontent.com/elhub/devxp-lint-configuration/main/resources/.mega-linter.yml"}
+			linterArgs := []string{"mega-linter-runner", "--flavor", "cupcake",
+				"-e", "LINTER_RULES_PATH=tmp/",
+				"-e", "MEGALINTER_CONFIG=https://raw.githubusercontent.com/elhub/devxp-lint-configuration/main/resources/.mega-linter.yml"}
 
 			linterArgs = append(linterArgs, "--filesonly")
 			linterArgs = append(linterArgs, utils.ConvertTerminalOutputIntoList(tt.modifiedFiles)...)

--- a/pkg/pr/prcreate_test.go
+++ b/pkg/pr/prcreate_test.go
@@ -226,7 +226,7 @@ func TestExecuteCreate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			linterArgs := []string{"mega-linter-runner", "--flavor", "cupcake",
-				"-e", "LINTER_RULES_PATH=tmp/",
+				"-e", "LINTER_RULES_PATH=/tmp",
 				"-e", "MEGALINTER_CONFIG=https://raw.githubusercontent.com/elhub/devxp-lint-configuration/main/resources/.mega-linter.yml"}
 
 			linterArgs = append(linterArgs, "--filesonly")

--- a/pkg/pr/prupdate_test.go
+++ b/pkg/pr/prupdate_test.go
@@ -150,7 +150,7 @@ func TestExecuteUpdate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			linterArgs := []string{"mega-linter-runner", "--flavor", "cupcake",
-				"-e", "LINTER_RULES_PATH=tmp/",
+				"-e", "LINTER_RULES_PATH=/tmp",
 				"-e", "MEGALINTER_CONFIG=https://raw.githubusercontent.com/elhub/devxp-lint-configuration/main/resources/.mega-linter.yml"}
 
 			linterArgs = append(linterArgs, "--filesonly")

--- a/pkg/pr/prupdate_test.go
+++ b/pkg/pr/prupdate_test.go
@@ -149,8 +149,9 @@ func TestExecuteUpdate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			linterArgs := []string{"mega-linter-runner", "--flavor", "cupcake", "-e",
-				"MEGALINTER_CONFIG=https://raw.githubusercontent.com/elhub/devxp-lint-configuration/main/resources/.mega-linter.yml"}
+			linterArgs := []string{"mega-linter-runner", "--flavor", "cupcake",
+				"-e", "LINTER_RULES_PATH=tmp/",
+				"-e", "MEGALINTER_CONFIG=https://raw.githubusercontent.com/elhub/devxp-lint-configuration/main/resources/.mega-linter.yml"}
 
 			linterArgs = append(linterArgs, "--filesonly")
 			linterArgs = append(linterArgs, utils.ConvertTerminalOutputIntoList(tt.modifiedFiles)...)


### PR DESCRIPTION
## 📝 Description

A common grievance with this extension is that running the lint command spams the user's repository with several lint configuration files. This change sets the configuration variable LINTER_RULES_PATH to /tmp, which presumably spams the /tmp directory of the container instead

## 📋 Checklist

* ✅ Lint checks passed on local machine.
* ✅ Unit tests passed on local machine.
