### PR TITLE
fix: add step to check out main if it does not exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ On the `alias.yml` file that follows this project. This installs a number of use
     gh extension install elhub/gh-dxp
     ```
 
+
 <details>
    <summary><strong>Install from source</strong></summary>
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ On the `alias.yml` file that follows this project. This installs a number of use
     gh extension install elhub/gh-dxp
     ```
 
-
 <details>
    <summary><strong>Install from source</strong></summary>
 

--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -88,6 +88,7 @@ func TestRun_LintWithNoExistingBranches(t *testing.T) {
 	mockExe := new(testutils.MockExecutor)
 	mockExe.On("Command", "git", []string{"branch"}).Return("", nil)
 	mockExe.On("Command", "git", []string{"status", "--porcelain"}).Return(" M /pkg/source.go\n M /pkg/source2.go", nil)
+	mockExe.On("Command", "git", []string{"fetch", "origin", "main"}).Return("", nil)
 
 	linterArgs := []string{
 		"mega-linter-runner", "--flavor", "cupcake",

--- a/pkg/pr/prcreate_test.go
+++ b/pkg/pr/prcreate_test.go
@@ -242,6 +242,7 @@ func TestExecuteCreate(t *testing.T) {
 			mockExe.On("Command", "git", []string{"add", "-u"}).Return("", nil)
 			mockExe.On("Command", "git", []string{"commit", "-m", "default commit message"}).Return("", nil)
 			mockExe.On("Command", "git", []string{"show-ref", "--verify", "--quiet", "refs/heads/" + tt.currentBranch})
+			mockExe.On("Command", "git", []string{"fetch", "origin", "main"}).Return("", nil)
 			mockExe.On("CommandContext", mock.Anything, "npx", linterArgs).Return("", tt.expectedLintErr)
 			mockExe.On("Command", "git", []string{"push", "--set-upstream", "origin", tt.currentBranch}).
 				Return(tt.pushBranch, tt.pushBranchErr)
@@ -259,7 +260,6 @@ func TestExecuteCreate(t *testing.T) {
 				Return(tt.prCreate, tt.prCreateErr)
 			mockExe.On("GH", []string{"repo", "view", "--json", "defaultBranchRef", "--jq", ".defaultBranchRef.name"}).
 				Return(tt.repoBranchName, tt.repoBranchErr)
-			mockExe.On("Command", "git", []string{"fetch, origin, main"}).Return("", nil)
 
 			err := pr.ExecuteCreate(mockExe,
 				&config.Settings{},

--- a/pkg/pr/prcreate_test.go
+++ b/pkg/pr/prcreate_test.go
@@ -259,6 +259,7 @@ func TestExecuteCreate(t *testing.T) {
 				Return(tt.prCreate, tt.prCreateErr)
 			mockExe.On("GH", []string{"repo", "view", "--json", "defaultBranchRef", "--jq", ".defaultBranchRef.name"}).
 				Return(tt.repoBranchName, tt.repoBranchErr)
+			mockExe.On("Command", "git", []string{"fetch, origin, main"}).Return("", nil)
 
 			err := pr.ExecuteCreate(mockExe,
 				&config.Settings{},

--- a/pkg/utils/files.go
+++ b/pkg/utils/files.go
@@ -21,6 +21,14 @@ func GetChangedFiles(exe Executor) ([]string, error) {
 
 	branchList := ConvertTerminalOutputIntoList(branchString)
 
+	// If main does not exist, we need to check it out in order to perform the comparison (relevant for new TC agents)
+	if !contains(branchList, "main") {
+		_, err := exe.Command("git", "fetch", "origin", "main")
+		if err != nil {
+			return []string{}, err
+		}
+	}
+
 	var changedFiles []string
 
 	if len(branchList) > 0 {
@@ -98,4 +106,13 @@ func filter(list []string, test func(string) bool) []string {
 		}
 	}
 	return ret
+}
+
+func contains(slice []string, item string) bool {
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## 📝 Description

This is needed to resolve an issue where the main branch is not present on newly created teamcity agents

## 🔗 Issue ID(s): TDX-972

## 📋 Checklist

* ✅ Lint checks passed on local machine.
* ⛔ **This PR has not been unit tested! The --notest option was used.**
* ✅ Documentation Updates: README
