### PR TITLE
Validate renovate.json with renovate-config-validator [minor]

### DIFF
--- a/.megalinter.yml
+++ b/.megalinter.yml
@@ -1,5 +1,0 @@
----
-EXTENDS:
-  - https://raw.githubusercontent.com/elhub/devxp-lint-configuration/main/resources/.mega-linter.yml
-
-JSON_JSONLINT_FILTER_REGEX_EXCLUDE: '.github/renovate.json'

--- a/.megalinter.yml
+++ b/.megalinter.yml
@@ -1,0 +1,5 @@
+---
+EXTENDS:
+  - https://raw.githubusercontent.com/elhub/devxp-lint-configuration/main/resources/.mega-linter.yml
+
+JSON_JSONLINT_FILTER_REGEX_EXCLUDE: '.github/renovate.json'

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -61,6 +61,7 @@ func GenerateCmd(settings *config.Settings, version string) (*cobra.Command, err
 		TestCmd(exe),
 		TemplateCmd(exe, settings),
 		StatusCmd(exe),
+		RenovateCmd(exe, settings),
 	)
 
 	return retCmd, nil

--- a/pkg/cmd/pr.go
+++ b/pkg/cmd/pr.go
@@ -1,3 +1,4 @@
+// Package cmd provides the main commands for the gh-dxp extension.
 package cmd
 
 import (

--- a/pkg/cmd/renovate.go
+++ b/pkg/cmd/renovate.go
@@ -1,3 +1,4 @@
+// Package cmd provides the main commands for the gh-dxp extension.
 package cmd
 
 import (

--- a/pkg/cmd/renovate.go
+++ b/pkg/cmd/renovate.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// RenovateCmd creates a new command for working with renovate.
 func RenovateCmd(exe utils.Executor, settings *config.Settings) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "renovate",
@@ -23,6 +24,7 @@ func RenovateCmd(exe utils.Executor, settings *config.Settings) *cobra.Command {
 	return cmd
 }
 
+// ValidateCmd creates a new command for validating renovate config.
 func ValidateCmd(exe utils.Executor, settings *config.Settings) *cobra.Command {
 	opts := &renovate.Options{}
 	cmd := &cobra.Command{
@@ -39,7 +41,7 @@ func ValidateCmd(exe utils.Executor, settings *config.Settings) *cobra.Command {
 			# Force validation of renovate config (for example even if it's unchanged)
 			$ gh dxp renovate validate --force
 		`),
-		RunE: func(prCmd *cobra.Command, _ []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			err := utils.SetWorkDirToGitHubRoot(exe)
 			if err != nil {
 				return err

--- a/pkg/cmd/renovate.go
+++ b/pkg/cmd/renovate.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/elhub/gh-dxp/pkg/config"
+	"github.com/elhub/gh-dxp/pkg/renovate"
+	"github.com/elhub/gh-dxp/pkg/utils"
+	"github.com/spf13/cobra"
+)
+
+func RenovateCmd(exe utils.Executor, settings *config.Settings) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "renovate",
+		Short: "Work with renovate",
+		Args:  cobra.MaximumNArgs(1),
+		Long: heredoc.Doc(`
+			The renovate command group allows you to validate renovate config.
+		`),
+	}
+
+	cmd.AddCommand(ValidateCmd(exe, settings))
+
+	return cmd
+}
+
+func ValidateCmd(exe utils.Executor, settings *config.Settings) *cobra.Command {
+	opts := &renovate.Options{}
+	cmd := &cobra.Command{
+		Use:   "validate",
+		Short: "validate renovate config",
+		Args:  cobra.MaximumNArgs(0),
+		Long: heredoc.Docf(`
+			Validate renovate config when changed.
+		`, "`"),
+		Example: heredoc.Doc(`
+			# Validate renovate config if modified from 'main' branch
+			$ gh dxp renovate validate
+
+			# Force validation of renovate config (for example even if it's unchanged)
+			$ gh dxp renovate validate --force
+		`),
+		RunE: func(prCmd *cobra.Command, _ []string) error {
+			err := utils.SetWorkDirToGitHubRoot(exe)
+			if err != nil {
+				return err
+			}
+			return renovate.Run(exe, settings, opts)
+		},
+	}
+
+	fl := cmd.Flags()
+	fl.BoolVarP(
+		&opts.Force,
+		"force",
+		"f",
+		false,
+		"Force validation even if there are no changes",
+	)
+
+	return cmd
+}

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -44,6 +44,7 @@ func Run(exe utils.Executor, _ *config.Settings, opts *Options) error {
 	}
 
 	args = append(args, "-e", "LINTER_RULES_PATH=/tmp") // Prevents mega-linter from spamming lint configuration files into the repository
+	args = append(args, "-e", "GOTOOLCHAIN=auto")   // Allow go to upgrade to latest version when running the linter, preventing linting errors
 
 	// Check if mega-lint configuration is present in the repository.
 	if !utils.FileExists(".mega-linter.yml") {

--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -22,6 +22,7 @@ func TestRun_LintNoErrors(t *testing.T) {
 	linterArgs := []string{
 		"mega-linter-runner", "--flavor", "cupcake",
 		"-e", "LINTER_RULES_PATH=/tmp",
+		"-e", "GOTOOLCHAIN=auto",
 		"-e", "MEGALINTER_CONFIG=https://raw.githubusercontent.com/elhub/devxp-lint-configuration/main/resources/.mega-linter.yml",
 		"--filesonly", "/pkg/source.go", "/pkg/source2.go",
 	}
@@ -44,6 +45,7 @@ func TestRun_LintHasErrors(t *testing.T) {
 	linterArgs := []string{
 		"mega-linter-runner", "--flavor", "cupcake",
 		"-e", "LINTER_RULES_PATH=/tmp",
+		"-e", "GOTOOLCHAIN=auto",
 		"-e", "MEGALINTER_CONFIG=https://raw.githubusercontent.com/elhub/devxp-lint-configuration/main/resources/.mega-linter.yml",
 		"--filesonly", "/pkg/source.go", "/pkg/source2.go",
 	}
@@ -61,6 +63,7 @@ func TestRun_LintAllFiles(t *testing.T) {
 	linterArgs := []string{
 		"mega-linter-runner", "--flavor", "cupcake",
 		"-e", "LINTER_RULES_PATH=/tmp",
+		"-e", "GOTOOLCHAIN=auto",
 		"-e", "MEGALINTER_CONFIG=https://raw.githubusercontent.com/elhub/devxp-lint-configuration/main/resources/.mega-linter.yml",
 	}
 
@@ -82,6 +85,7 @@ func TestRun_LintWithFix(t *testing.T) {
 	linterArgs := []string{
 		"mega-linter-runner", "--flavor", "cupcake",
 		"-e", "LINTER_RULES_PATH=/tmp",
+		"-e", "GOTOOLCHAIN=auto",
 		"-e", "MEGALINTER_CONFIG=https://raw.githubusercontent.com/elhub/devxp-lint-configuration/main/resources/.mega-linter.yml",
 		"--filesonly", "/pkg/source.go", "/pkg/source2.go", "--fix",
 	}
@@ -101,6 +105,7 @@ func TestRun_LintWithNoExistingBranches(t *testing.T) {
 	linterArgs := []string{
 		"mega-linter-runner", "--flavor", "cupcake",
 		"-e", "LINTER_RULES_PATH=/tmp",
+		"-e", "GOTOOLCHAIN=auto",
 		"-e", "MEGALINTER_CONFIG=https://raw.githubusercontent.com/elhub/devxp-lint-configuration/main/resources/.mega-linter.yml",
 		"--filesonly", "/pkg/source.go", "/pkg/source2.go",
 	}
@@ -118,6 +123,7 @@ func TestRun_LintSpecificDirectory(t *testing.T) {
 	linterArgs := []string{
 		"mega-linter-runner", "--flavor", "cupcake",
 		"-e", "LINTER_RULES_PATH=/tmp",
+		"-e", "GOTOOLCHAIN=auto",
 		"-e", "MEGALINTER_CONFIG=https://raw.githubusercontent.com/elhub/devxp-lint-configuration/main/resources/.mega-linter.yml",
 		"-e", "FILTER_REGEX_INCLUDE=(pkg)",
 	}
@@ -135,6 +141,7 @@ func TestRun_UseProxy(t *testing.T) {
 	linterArgs := []string{
 		"mega-linter-runner", "--flavor", "cupcake",
 		"-e", "LINTER_RULES_PATH=/tmp",
+		"-e", "GOTOOLCHAIN=auto",
 		"-e", "MEGALINTER_CONFIG=https://raw.githubusercontent.com/elhub/devxp-lint-configuration/main/resources/.mega-linter.yml",
 		"-e", "FILTER_REGEX_INCLUDE=(pkg)", "-e", "https_proxy=https://myproxy.no:8080",
 	}

--- a/pkg/pr/pr.go
+++ b/pkg/pr/pr.go
@@ -7,6 +7,7 @@ import (
 	"github.com/elhub/gh-dxp/pkg/config"
 	"github.com/elhub/gh-dxp/pkg/lint"
 	"github.com/elhub/gh-dxp/pkg/logger"
+	"github.com/elhub/gh-dxp/pkg/renovate"
 	"github.com/elhub/gh-dxp/pkg/test"
 	"github.com/elhub/gh-dxp/pkg/utils"
 	"github.com/pkg/errors"
@@ -138,6 +139,12 @@ func performPreCommitOperations(exe utils.Executor, settings *config.Settings, p
 	// Run lint
 	if !options.NoLint {
 		err = lint.Run(exe, settings, &lint.Options{})
+		if err != nil {
+			return pr, err
+		}
+
+		// Run renovate config validation
+		err = renovate.Run(exe, settings, &renovate.Options{})
 		if err != nil {
 			return pr, err
 		}

--- a/pkg/pr/prcreate_test.go
+++ b/pkg/pr/prcreate_test.go
@@ -240,6 +240,7 @@ func TestExecuteCreate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			linterArgs := []string{"mega-linter-runner", "--flavor", "cupcake",
 				"-e", "LINTER_RULES_PATH=/tmp",
+				"-e", "GOTOOLCHAIN=auto",
 				"-e", "MEGALINTER_CONFIG=https://raw.githubusercontent.com/elhub/devxp-lint-configuration/main/resources/.mega-linter.yml"}
 
 			linterArgs = append(linterArgs, "--filesonly")

--- a/pkg/pr/prupdate_test.go
+++ b/pkg/pr/prupdate_test.go
@@ -156,6 +156,7 @@ func TestExecuteUpdate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			linterArgs := []string{"mega-linter-runner", "--flavor", "cupcake",
 				"-e", "LINTER_RULES_PATH=/tmp",
+				"-e", "GOTOOLCHAIN=auto",
 				"-e", "MEGALINTER_CONFIG=https://raw.githubusercontent.com/elhub/devxp-lint-configuration/main/resources/.mega-linter.yml"}
 
 			linterArgs = append(linterArgs, "--filesonly")

--- a/pkg/renovate/model.go
+++ b/pkg/renovate/model.go
@@ -1,6 +1,6 @@
 package renovate
 
-// Options represents the options for the lint command.
+// Options represents the options for the renovate command.
 type Options struct {
 	Force		bool
 }

--- a/pkg/renovate/model.go
+++ b/pkg/renovate/model.go
@@ -1,0 +1,6 @@
+package renovate
+
+// Options represents the options for the lint command.
+type Options struct {
+	Force		bool
+}

--- a/pkg/renovate/model.go
+++ b/pkg/renovate/model.go
@@ -1,3 +1,4 @@
+// Package renovate provides functionality to validate renovate configuration files.
 package renovate
 
 // Options represents the options for the renovate command.

--- a/pkg/renovate/renovate.go
+++ b/pkg/renovate/renovate.go
@@ -8,8 +8,9 @@ import (
 	"github.com/elhub/gh-dxp/pkg/utils"
 )
 
+// Run executes the renovate validation process.
 func Run(exe utils.Executor, _ *config.Settings, opts *Options) error {
-	err, renovateConfigChanged := isRenovateConfigUpdated(exe)
+	renovateConfigChanged, err := isRenovateConfigUpdated(exe)
 	if err != nil {
 		logger.Info("The validation process returned an error looking for renovate config file: " + err.Error() + "\n")
 		return err
@@ -31,21 +32,22 @@ func Run(exe utils.Executor, _ *config.Settings, opts *Options) error {
 	return nil
 }
 
-func isRenovateConfigUpdated(exe utils.Executor) (error, bool) {
+// isRenovateConfigUpdated checks if the renovate config file has been updated compared to the main branch.
+func isRenovateConfigUpdated(exe utils.Executor) (bool, error) {
 	changedFiles, err := utils.GetChangedFiles(exe)
 	if err != nil {
-		return err, false
+		return false, err
 	}
 
 	if len(changedFiles) == 0 {
 		logger.Info("Did not find any changed files to validate")
-		return nil, false
+		return false, nil
 	}
 
 	for _, file := range changedFiles {
 		if file == ".github/renovate.json" {
-			return nil, true
+			return true, nil
 		}
 	}
-	return nil, false
+	return false, nil
 }

--- a/pkg/renovate/renovate.go
+++ b/pkg/renovate/renovate.go
@@ -1,0 +1,51 @@
+package renovate
+
+import (
+	"context"
+
+	"github.com/elhub/gh-dxp/pkg/config"
+	"github.com/elhub/gh-dxp/pkg/logger"
+	"github.com/elhub/gh-dxp/pkg/utils"
+)
+
+func Run(exe utils.Executor, _ *config.Settings, opts *Options) error {
+	err, renovateConfigChanged := isRenovateConfigUpdated(exe)
+	if err != nil {
+		logger.Info("The validation process returned an error looking for renovate config file: " + err.Error() + "\n")
+		return err
+	}
+
+	if !renovateConfigChanged && !opts.Force {
+		logger.Info("The renovate config has not changed, skipping...")
+		return nil
+	}
+
+	args := []string{"npx", "--package", "renovate@43.78.0", "renovate-config-validator", "--strict"}
+	ctx := context.Background()
+	err = exe.CommandContext(ctx, args[0], args[1:]...)
+
+	if err != nil {
+		logger.Info("The validation process returned an error: " + err.Error() + "\n")
+		return err
+	}
+	return nil
+}
+
+func isRenovateConfigUpdated(exe utils.Executor) (error, bool) {
+	changedFiles, err := utils.GetChangedFiles(exe)
+	if err != nil {
+		return err, false
+	}
+
+	if len(changedFiles) == 0 {
+		logger.Info("Did not find any changed files to validate")
+		return nil, false
+	}
+
+	for _, file := range changedFiles {
+		if file == ".github/renovate.json" {
+			return nil, true
+		}
+	}
+	return nil, false
+}

--- a/pkg/renovate/renovate.go
+++ b/pkg/renovate/renovate.go
@@ -1,3 +1,4 @@
+// Package renovate provides functionality to validate renovate configuration files.
 package renovate
 
 import (

--- a/pkg/renovate/renovate_test.go
+++ b/pkg/renovate/renovate_test.go
@@ -10,7 +10,8 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
-const MAIN_BRANCH = "origin/main"
+
+const MainBranch = "origin/main"
 
 func TestRenovateRunOnChange(t *testing.T) {
 	mockExe := new(testutils.MockExecutor)
@@ -19,7 +20,7 @@ func TestRenovateRunOnChange(t *testing.T) {
 	mockExe.On("Command", "git", []string{"fetch", "origin", "main"}).Return("", nil)
 	mockExe.On("Command", "git", []string{"remote", "set-head", "origin", "--auto"}).Return("", nil)
 	mockExe.On("Command", "git", []string{"symbolic-ref", "--short", "refs/remotes/origin/HEAD"}).Return("origin/main", nil)
-	mockExe.On("Command", "git", []string{"diff", "--name-only", MAIN_BRANCH, "--relative"}).Return(".github/renovate.json", nil)
+	mockExe.On("Command", "git", []string{"diff", "--name-only", MainBranch, "--relative"}).Return(".github/renovate.json", nil)
 
 	renovateArgs := []string{
 		"--package", "renovate@43.78.0", "renovate-config-validator", "--strict",
@@ -43,8 +44,8 @@ func TestRenovateNoRunOnNoChange(t *testing.T) {
 	mockExe.On("Command", "git", []string{"branch"}).Return("main\ndifferentBranch\n", nil)
 	mockExe.On("Command", "git", []string{"fetch", "origin", "main"}).Return("", nil)
 	mockExe.On("Command", "git", []string{"remote", "set-head", "origin", "--auto"}).Return("", nil)
-	mockExe.On("Command", "git", []string{"symbolic-ref", "--short", "refs/remotes/origin/HEAD"}).Return(MAIN_BRANCH, nil)
-	mockExe.On("Command", "git", []string{"diff", "--name-only", MAIN_BRANCH, "--relative"}).Return("file1.txt", nil)
+	mockExe.On("Command", "git", []string{"symbolic-ref", "--short", "refs/remotes/origin/HEAD"}).Return(MainBranch, nil)
+	mockExe.On("Command", "git", []string{"diff", "--name-only", MainBranch, "--relative"}).Return("file1.txt", nil)
 
 	err := renovate.Run(mockExe, &config.Settings{}, &renovate.Options{})
 
@@ -64,8 +65,8 @@ func TestRenovateRunOnNoChangeWithForce(t *testing.T) {
 	mockExe.On("Command", "git", []string{"branch"}).Return("main\ndifferentBranch\n", nil)
 	mockExe.On("Command", "git", []string{"fetch", "origin", "main"}).Return("", nil)
 	mockExe.On("Command", "git", []string{"remote", "set-head", "origin", "--auto"}).Return("", nil)
-	mockExe.On("Command", "git", []string{"symbolic-ref", "--short", "refs/remotes/origin/HEAD"}).Return(MAIN_BRANCH, nil)
-	mockExe.On("Command", "git", []string{"diff", "--name-only", MAIN_BRANCH, "--relative"}).Return("file1.txt", nil)
+	mockExe.On("Command", "git", []string{"symbolic-ref", "--short", "refs/remotes/origin/HEAD"}).Return(MainBranch, nil)
+	mockExe.On("Command", "git", []string{"diff", "--name-only", MainBranch, "--relative"}).Return("file1.txt", nil)
 
 	renovateArgs := []string{
 		"--package", "renovate@43.78.0", "renovate-config-validator", "--strict",

--- a/pkg/renovate/renovate_test.go
+++ b/pkg/renovate/renovate_test.go
@@ -18,28 +18,24 @@ func TestRenovateValidationError(t *testing.T) {
 		name	  		string
 		filesChanged	string
 		forceValidate	bool
-		expectedErr 	error
 		expectedRun		bool
 	}{
 		{
 			name:	 		"Test run on renovate config change",
 			filesChanged:	".github/renovate.json",
 			forceValidate: 	false,
-			expectedErr:	nil,
 			expectedRun: 	true,
 		},
 		{
 			name:	  		"Test don't run with no renovate config changes",
 			filesChanged:	"file1.txt\nfile2.txt",
 			forceValidate: 	false,
-			expectedErr:	nil,
 			expectedRun: 	false,
 		},
 		{
 			name:			"Test run with no renovate config changes and --force used",
 			filesChanged:	"file1.txt\nfile2.txt",
 			forceValidate: 	true,
-			expectedErr:	nil,
 			expectedRun: 	true,
 		},
 	}
@@ -63,11 +59,7 @@ func TestRenovateValidationError(t *testing.T) {
 
 			err := renovate.Run(mockExe, &config.Settings{}, &renovate.Options{Force: tt.forceValidate})
 
-			if tt.expectedErr != nil {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-			}
+			require.NoError(t, err)
 
 			if (!tt.expectedRun) {
 				mockExe.AssertNotCalled(t, "CommandContext", mock.Anything, "npx", renovateArgs)

--- a/pkg/renovate/renovate_test.go
+++ b/pkg/renovate/renovate_test.go
@@ -1,7 +1,6 @@
 package renovate_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/elhub/gh-dxp/pkg/config"
@@ -13,75 +12,68 @@ import (
 
 const MainBranch = "origin/main"
 
-func TestRenovateRunOnChange(t *testing.T) {
-	mockExe := new(testutils.MockExecutor)
 
-	mockExe.On("Command", "git", []string{"branch"}).Return("main\ndifferentBranch\n", nil)
-	mockExe.On("Command", "git", []string{"fetch", "origin", "main"}).Return("", nil)
-	mockExe.On("Command", "git", []string{"remote", "set-head", "origin", "--auto"}).Return("", nil)
-	mockExe.On("Command", "git", []string{"symbolic-ref", "--short", "refs/remotes/origin/HEAD"}).Return("origin/main", nil)
-	mockExe.On("Command", "git", []string{"diff", "--name-only", MainBranch, "--relative"}).Return(".github/renovate.json", nil)
-
-	renovateArgs := []string{
-		"--package", "renovate@43.78.0", "renovate-config-validator", "--strict",
+func TestRenovateValidationError(t *testing.T) {
+	test := []struct {
+		name	  		string
+		filesChanged	string
+		forceValidate	bool
+		expectedErr 	error
+		expectedRun		bool
+	}{
+		{
+			name:	 		"Test run on renovate config change",
+			filesChanged:	".github/renovate.json",
+			forceValidate: 	false,
+			expectedErr:	nil,
+			expectedRun: 	true,
+		},
+		{
+			name:	  		"Test don't run with no renovate config changes",
+			filesChanged:	"file1.txt\nfile2.txt",
+			forceValidate: 	false,
+			expectedErr:	nil,
+			expectedRun: 	false,
+		},
+		{
+			name:			"Test run with no renovate config changes and --force used",
+			filesChanged:	"file1.txt\nfile2.txt",
+			forceValidate: 	true,
+			expectedErr:	nil,
+			expectedRun: 	true,
+		},
 	}
 
-	mockExe.On("CommandContext", mock.Anything, "npx", renovateArgs).Return(nil, nil)
+	for _, tt := range test {
+		t.Run(tt.name, func(t *testing.T) {
+			mockExe := new(testutils.MockExecutor)
+			mockExe.On("Command", "git", []string{"branch"}).Return("main\ndifferentBranch\n", nil)
+			mockExe.On("Command", "git", []string{"fetch", "origin", "main"}).Return("", nil)
+			mockExe.On("Command", "git", []string{"remote", "set-head", "origin", "--auto"}).Return("", nil)
+			mockExe.On("Command", "git", []string{"symbolic-ref", "--short", "refs/remotes/origin/HEAD"}).Return("origin/main", nil)
+			mockExe.On("Command", "git", []string{"diff", "--name-only", MainBranch, "--relative"}).Return(tt.filesChanged, nil)
 
-	err := renovate.Run(mockExe, &config.Settings{}, &renovate.Options{})
-	require.NoError(t, err)
+			renovateArgs := []string{
+				"--package", "renovate@43.78.0", "renovate-config-validator", "--strict",
+			}
 
-	for _, call := range mockExe.Calls {
-		fmt.Printf("Called: %s with %v\n", call.Method, call.Arguments)
+			if (tt.expectedRun) {
+				mockExe.On("CommandContext", mock.Anything, "npx", renovateArgs).Return(nil, nil)
+			}
+
+			err := renovate.Run(mockExe, &config.Settings{}, &renovate.Options{Force: tt.forceValidate})
+
+			if tt.expectedErr != nil {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			if (!tt.expectedRun) {
+				mockExe.AssertNotCalled(t, "CommandContext", mock.Anything, "npx", renovateArgs)
+			}
+
+			mockExe.AssertExpectations(t)
+		})
 	}
-
-	mockExe.AssertExpectations(t)
-}
-
-func TestRenovateNoRunOnNoChange(t *testing.T) {
-	mockExe := new(testutils.MockExecutor)
-
-	mockExe.On("Command", "git", []string{"branch"}).Return("main\ndifferentBranch\n", nil)
-	mockExe.On("Command", "git", []string{"fetch", "origin", "main"}).Return("", nil)
-	mockExe.On("Command", "git", []string{"remote", "set-head", "origin", "--auto"}).Return("", nil)
-	mockExe.On("Command", "git", []string{"symbolic-ref", "--short", "refs/remotes/origin/HEAD"}).Return(MainBranch, nil)
-	mockExe.On("Command", "git", []string{"diff", "--name-only", MainBranch, "--relative"}).Return("file1.txt", nil)
-
-	err := renovate.Run(mockExe, &config.Settings{}, &renovate.Options{})
-
-	require.NoError(t, err)
-
-	for _, call := range mockExe.Calls {
-		fmt.Printf("Called: %s with %v\n", call.Method, call.Arguments)
-	}
-
-	mockExe.AssertNotCalled(t, "CommandContext", mock.Anything, "npx", mock.Anything)
-	mockExe.AssertExpectations(t)
-}
-
-func TestRenovateRunOnNoChangeWithForce(t *testing.T) {
-	mockExe := new(testutils.MockExecutor)
-
-	mockExe.On("Command", "git", []string{"branch"}).Return("main\ndifferentBranch\n", nil)
-	mockExe.On("Command", "git", []string{"fetch", "origin", "main"}).Return("", nil)
-	mockExe.On("Command", "git", []string{"remote", "set-head", "origin", "--auto"}).Return("", nil)
-	mockExe.On("Command", "git", []string{"symbolic-ref", "--short", "refs/remotes/origin/HEAD"}).Return(MainBranch, nil)
-	mockExe.On("Command", "git", []string{"diff", "--name-only", MainBranch, "--relative"}).Return("file1.txt", nil)
-
-	renovateArgs := []string{
-		"--package", "renovate@43.78.0", "renovate-config-validator", "--strict",
-	}
-
-
-	mockExe.On("CommandContext", mock.Anything, "npx", renovateArgs).Return(nil, nil)
-
-	err := renovate.Run(mockExe, &config.Settings{}, &renovate.Options{Force: true})
-
-	require.NoError(t, err)
-
-	for _, call := range mockExe.Calls {
-		fmt.Printf("Called: %s with %v\n", call.Method, call.Arguments)
-	}
-
-	mockExe.AssertExpectations(t)
 }

--- a/pkg/renovate/renovate_test.go
+++ b/pkg/renovate/renovate_test.go
@@ -1,0 +1,86 @@
+package renovate_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/elhub/gh-dxp/pkg/config"
+	"github.com/elhub/gh-dxp/pkg/renovate"
+	"github.com/elhub/gh-dxp/pkg/testutils"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+const MAIN_BRANCH = "origin/main"
+
+func TestRenovateRunOnChange(t *testing.T) {
+	mockExe := new(testutils.MockExecutor)
+
+	mockExe.On("Command", "git", []string{"branch"}).Return("main\ndifferentBranch\n", nil)
+	mockExe.On("Command", "git", []string{"fetch", "origin", "main"}).Return("", nil)
+	mockExe.On("Command", "git", []string{"remote", "set-head", "origin", "--auto"}).Return("", nil)
+	mockExe.On("Command", "git", []string{"symbolic-ref", "--short", "refs/remotes/origin/HEAD"}).Return("origin/main", nil)
+	mockExe.On("Command", "git", []string{"diff", "--name-only", MAIN_BRANCH, "--relative"}).Return(".github/renovate.json", nil)
+
+	renovateArgs := []string{
+		"--package", "renovate@43.78.0", "renovate-config-validator", "--strict",
+	}
+
+	mockExe.On("CommandContext", mock.Anything, "npx", renovateArgs).Return(nil, nil)
+
+	err := renovate.Run(mockExe, &config.Settings{}, &renovate.Options{})
+	require.NoError(t, err)
+
+	for _, call := range mockExe.Calls {
+		fmt.Printf("Called: %s with %v\n", call.Method, call.Arguments)
+	}
+
+	mockExe.AssertExpectations(t)
+}
+
+func TestRenovateNoRunOnNoChange(t *testing.T) {
+	mockExe := new(testutils.MockExecutor)
+
+	mockExe.On("Command", "git", []string{"branch"}).Return("main\ndifferentBranch\n", nil)
+	mockExe.On("Command", "git", []string{"fetch", "origin", "main"}).Return("", nil)
+	mockExe.On("Command", "git", []string{"remote", "set-head", "origin", "--auto"}).Return("", nil)
+	mockExe.On("Command", "git", []string{"symbolic-ref", "--short", "refs/remotes/origin/HEAD"}).Return(MAIN_BRANCH, nil)
+	mockExe.On("Command", "git", []string{"diff", "--name-only", MAIN_BRANCH, "--relative"}).Return("file1.txt", nil)
+
+	err := renovate.Run(mockExe, &config.Settings{}, &renovate.Options{})
+
+	require.NoError(t, err)
+
+	for _, call := range mockExe.Calls {
+		fmt.Printf("Called: %s with %v\n", call.Method, call.Arguments)
+	}
+
+	mockExe.AssertNotCalled(t, "CommandContext", mock.Anything, "npx", mock.Anything)
+	mockExe.AssertExpectations(t)
+}
+
+func TestRenovateRunOnNoChangeWithForce(t *testing.T) {
+	mockExe := new(testutils.MockExecutor)
+
+	mockExe.On("Command", "git", []string{"branch"}).Return("main\ndifferentBranch\n", nil)
+	mockExe.On("Command", "git", []string{"fetch", "origin", "main"}).Return("", nil)
+	mockExe.On("Command", "git", []string{"remote", "set-head", "origin", "--auto"}).Return("", nil)
+	mockExe.On("Command", "git", []string{"symbolic-ref", "--short", "refs/remotes/origin/HEAD"}).Return(MAIN_BRANCH, nil)
+	mockExe.On("Command", "git", []string{"diff", "--name-only", MAIN_BRANCH, "--relative"}).Return("file1.txt", nil)
+
+	renovateArgs := []string{
+		"--package", "renovate@43.78.0", "renovate-config-validator", "--strict",
+	}
+
+
+	mockExe.On("CommandContext", mock.Anything, "npx", renovateArgs).Return(nil, nil)
+
+	err := renovate.Run(mockExe, &config.Settings{}, &renovate.Options{Force: true})
+
+	require.NoError(t, err)
+
+	for _, call := range mockExe.Calls {
+		fmt.Printf("Called: %s with %v\n", call.Method, call.Arguments)
+	}
+
+	mockExe.AssertExpectations(t)
+}


### PR DESCRIPTION
## 📝 Description

This attempts to resolve the conflict between jsonlint and renovate wanting different formats in the config json files.

## 🔗 Issue ID(s): [TDX-1523](https://elhub.atlassian.net/browse/TDX-1523)

## 📋 Checklist

* ✅ Lint checks passed on local machine.
* ✅ Unit tests passed on local machine.
* ✅ This PR adds new tests.


[TDX-1523]: https://elhub.atlassian.net/browse/TDX-1523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ