### PR TITLE
feat: bumping lint image to 10 / gitleaks -> betterleaks migration

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,7 +28,7 @@ func DefaultSettings() *Settings {
 		ProjectTemplateURI:     "https://raw.githubusercontent.com/elhub/devxp-project-template/main/resources/",
 		JiraURL:                "https://elhub.atlassian.net/browse",
 		ProjectType:            "",
-		MegalinterImageVersion: "docker.jfrog.elhub.cloud/oxsecurity/megalinter-cupcake:v9.6.0",
+		MegalinterImageVersion: "docker.jfrog.elhub.cloud/oxsecurity/megalinter-cupcake:v10.0.0",
 	}
 }
 


### PR DESCRIPTION
there is a renovate rule for bumping this already, but doing it manually to control another simultaneously needed change:
[this pr](https://github.com/elhub/devxp-lint-configuration/pull/145) to move from gitleaks to betterleaks in lint config

in v10 the existing `REPOSITORY_GITLEAKS` will be a no-op (ref [docs](https://megalinter.io/latest/descriptors/repository_betterleaks/))

https://elhub.atlassian.net/browse/TDX-1718

see also [adr proposal](https://github.com/elhub/devxp/pull/900) (need to merge that before this)