### PR TITLE
fix: increase label list limit

### DIFF
--- a/pkg/pr/prcreate.go
+++ b/pkg/pr/prcreate.go
@@ -123,7 +123,7 @@ func create(exe ghutil.Executor, options *CreateOptions, settings *config.Settin
 }
 
 func ensureLabelExistsInRepository(exe ghutil.Executor, labelName string) error {
-	stdOut, err := exe.GH("label", "list", "--json", "name", "--jq", ".[].name")
+	stdOut, err := exe.GH("label", "list", "--limit", "1000", "--json", "name", "--jq", ".[].name")
 	if err != nil {
 		return err
 	}

--- a/pkg/pr/prcreate_test.go
+++ b/pkg/pr/prcreate_test.go
@@ -289,7 +289,7 @@ func TestExecuteCreate(t *testing.T) {
 				Return(tt.prCreate, tt.prCreateErr)
 			mockExe.On("GH", []string{"repo", "view", "--json", "defaultBranchRef", "--jq", ".defaultBranchRef.name"}).
 				Return(tt.repoBranchName, tt.repoBranchErr)
-			mockExe.On("GH", []string{"label", "list", "--json", "name", "--jq", ".[].name"}).
+			mockExe.On("GH", []string{"label", "list", "--limit", "1000", "--json", "name", "--jq", ".[].name"}).
 				Return("", tt.labelCheckErr)
 			mockExe.On("GH", []string{"label", "create", "Test", "--color", "#fbca04", "--description", "A test PR is a pull request that adds or updates tests."}).
 				Return("", tt.labelCreateErr)


### PR DESCRIPTION
## 📝 Description

Encountered an issue where the default amount listed wasn't enough, and so the extension tried to create a label that already existed, leading to errors.

## 📋 Checklist

* ✅ Lint checks passed on local machine.
* ✅ Unit tests passed on local machine.
